### PR TITLE
fix: move dotenv require on top

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,9 +1,8 @@
-const Discord = require('discord.js')
-const {onboarding, commands} = require('./src')
-
 require('dotenv').config({
   path: `.env.${process.env.NODE_ENV || 'local'}`,
 })
+const Discord = require('discord.js')
+const {onboarding, commands} = require('./src')
 
 const client = new Discord.Client()
 


### PR DESCRIPTION


**What**: I have moved the require of `dotenv` on the top of the file

<!-- Why are these changes necessary? -->

**Why**: Because if you run `npm start` using a `.env` file the script gave error because in `utils.js` an error is  thrown when env variables are not provided 

<!-- How were these changes implemented? -->

**How**: 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [x] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
