### PR TITLE
feat: add the new private-chat command

### DIFF
--- a/src/commands/command-fns/private-chat.js
+++ b/src/commands/command-fns/private-chat.js
@@ -1,0 +1,106 @@
+const Discord = require('discord.js')
+const {privateChannelPrefix, getSend} = require('../utils')
+
+async function privateChat(message) {
+  const mentionedMembers = Array.from(message.mentions.members.values())
+  const mentionedMembersNicknames = Array.from(
+    message.mentions.members.values(),
+  ).map(m => m.nickname ?? m.user.username)
+  if (mentionedMembers.length < 2) {
+    return message.channel.send(`You should mention at least two members.`)
+  }
+
+  const allPermissions = Object.keys(Discord.Permissions.FLAGS)
+  const membersPermissions = mentionedMembers.map(member => {
+    return {
+      type: 'member',
+      id: member.id,
+      allow: [
+        'ADD_REACTIONS',
+        'VIEW_CHANNEL',
+        'SEND_MESSAGES',
+        'SEND_TTS_MESSAGES',
+        'READ_MESSAGE_HISTORY',
+        'CHANGE_NICKNAME',
+      ],
+    }
+  })
+
+  let channelSuffix
+  if (mentionedMembersNicknames.length === 2) {
+    channelSuffix = mentionedMembersNicknames.join('-')
+  } else {
+    channelSuffix = `${mentionedMembersNicknames
+      .slice(0, 2)
+      .join('-')}-and-others`
+  }
+
+  const everyoneRole = message.guild.roles.cache.find(
+    ({name}) => name === '@everyone',
+  )
+
+  const categoryPrivateChat = message.guild.channels.cache.find(
+    ({name, type}) =>
+      type === 'category' && name.toLowerCase().includes('private chat'),
+  )
+
+  const allActivePrivateChannels = message.guild.channels.cache.filter(
+    channel =>
+      channel.type === 'text' &&
+      channel.parentID === categoryPrivateChat.id &&
+      channel.name.includes('-private-') &&
+      !channel.deleted,
+  )
+
+  const existingChat = allActivePrivateChannels.find(channel => {
+    const chatMembers = channel.members
+      .filter(member => !member.user.bot)
+      .map(member => member.id)
+
+    return (
+      chatMembers.length === mentionedMembers.length &&
+      mentionedMembers.every(member => chatMembers.indexOf(member.id) !== -1)
+    )
+  })
+
+  if (existingChat) {
+    return message.channel.send(`There is already a chat for the same members`)
+  }
+
+  const channel = await message.guild.channels.create(
+    `${privateChannelPrefix}${channelSuffix}`,
+    {
+      topic: `Private Chat`,
+      parent: categoryPrivateChat,
+      permissionOverwrites: [
+        {
+          type: 'role',
+          id: everyoneRole.id,
+          deny: allPermissions,
+        },
+        ...membersPermissions,
+      ],
+    },
+  )
+
+  const send = getSend(channel)
+
+  await send(
+    `
+Hello all 👋
+
+I'm a bot I have created this channel for you. The channel will be deleted after 1 hour or after 10 minutes for inactivity. Enjoy 🗣 
+    `.trim(),
+  )
+}
+privateChat.description =
+  'Create a private channel with you want. This channel will be de'
+privateChat.help = message =>
+  message.channel.send(
+    `Use this command to create a private chat with members of the server 🤫. 
+The chat will be deleted after 1 hour 👻 or if there is at least 10 minutes of inactivity 🚶‍♂️.
+Example of usage: ?private-chat @Exual1982 @Prours58
+    `,
+  )
+
+module.exports = privateChat

--- a/src/commands/command-fns/private-chat.js
+++ b/src/commands/command-fns/private-chat.js
@@ -1,5 +1,5 @@
 const Discord = require('discord.js')
-const {privateChannelPrefix, getSend} = require('../utils')
+const {privateChannelPrefix} = require('../utils')
 
 async function privateChat(message) {
   const mentionedMembers = Array.from(message.mentions.members.values())
@@ -64,7 +64,9 @@ async function privateChat(message) {
   })
 
   if (existingChat) {
-    return message.channel.send(`There is already a chat for the same members`)
+    return message.channel.send(
+      `There is already a chat for the same members ${existingChat}`,
+    )
   }
 
   const channel = await message.guild.channels.create(
@@ -83,11 +85,9 @@ async function privateChat(message) {
     },
   )
 
-  const send = getSend(channel)
-
-  await send(
+  await channel.send(
     `
-Hello all 👋
+Hello ${mentionedMembers.map(member => member.user).join(' ')} 👋
 
 I'm a bot I have created this channel for you. The channel will be deleted after 1 hour or after 10 minutes for inactivity. Enjoy 🗣 
     `.trim(),

--- a/src/commands/command-fns/private-chat.js
+++ b/src/commands/command-fns/private-chat.js
@@ -2,12 +2,12 @@ const Discord = require('discord.js')
 const {privateChannelPrefix} = require('../utils')
 
 async function privateChat(message) {
-  const mentionedMembers = Array.from(message.mentions.members.values())
+  const mentionedMembers = [...Array.from(message.mentions.members.values()), message.member]
   const mentionedMembersNicknames = Array.from(
     message.mentions.members.values(),
   ).map(m => m.nickname ?? m.user.username)
   if (mentionedMembers.length < 2) {
-    return message.channel.send(`You should mention at least two members.`)
+    return message.channel.send(`You should mention at least one other member.`)
   }
 
   const allPermissions = Object.keys(Discord.Permissions.FLAGS)

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -6,4 +6,5 @@ module.exports = {
   clubs: require('./command-fns/clubs'),
   info: require('./command-fns/info'),
   ping: require('./command-fns/ping'),
+  'private-chat': require('./command-fns/private-chat'),
 }

--- a/src/index.js
+++ b/src/index.js
@@ -2,6 +2,7 @@ const onboarding = require('./onboarding')
 const commands = require('./commands')
 const admin = require('./admin')
 const clubApplication = require('./club-application')
+const privateChat = require('./private-chat')
 const rollbar = require('./rollbar')
 
 function setup(client) {
@@ -9,6 +10,7 @@ function setup(client) {
   commands.setup(client)
   admin.setup(client)
   clubApplication.setup(client)
+  privateChat.setup(client)
 }
 
 module.exports = {

--- a/src/private-chat/cleanup.js
+++ b/src/private-chat/cleanup.js
@@ -40,9 +40,9 @@ async function cleanup(guild) {
       }
       await send(
         `
-    This channel is getting deleted for the following reason: ${reason}
-    
-    Goodbye 👋
+This channel is getting deleted for the following reason: ${reason}
+
+Goodbye 👋
         `.trim(),
       )
 
@@ -78,7 +78,7 @@ async function cleanup(guild) {
       }
       await send(
         `
-    This channel will be deleted in 5 minutes for the following reason: ${reason}
+This channel will be deleted in 5 minutes for the following reason: ${reason}
         `.trim(),
       )
     }

--- a/src/private-chat/cleanup.js
+++ b/src/private-chat/cleanup.js
@@ -1,0 +1,75 @@
+const {getSend, sleep} = require('../utils')
+const warnedChannels = new Set()
+
+async function cleanup(guild) {
+  const categoryPrivateChat = guild.channels.cache.find(
+    ({name, type}) =>
+      type === 'category' && name.toLowerCase().includes('private chat'),
+  )
+
+  const warningStep = 1000 * 60 * 5
+  const maxExistingTime = 1000 * 60 * 60
+  const maxInactiveTime = 1000 * 60 * 10
+  const eolReason = 'deleted for end of life 👻'
+  const inactivityReason = 'deleted for inactivity 🚶‍♀️'
+
+  const allActivePrivateChannels = guild.channels.cache.filter(
+    channel =>
+      channel.type === 'text' &&
+      channel.parentID === categoryPrivateChat.id &&
+      channel.name.includes('-private-') &&
+      !channel.deleted,
+  )
+
+  allActivePrivateChannels.forEach(async channel => {
+    const channelCreateDate = channel.createdAt
+    const lastMessageDate = channel.lastMessage?.createdAt ?? channelCreateDate
+    const timeSinceChannelCreation = new Date() - channelCreateDate
+    const timeSinceLastMessage = new Date() - lastMessageDate
+    const send = getSend(channel)
+    if (
+      timeSinceChannelCreation > maxExistingTime ||
+      timeSinceLastMessage > maxInactiveTime
+    ) {
+      let reason
+      if (timeSinceChannelCreation > maxExistingTime) {
+        reason = eolReason
+      } else {
+        reason = inactivityReason
+      }
+      await send(
+        `
+    This channel is getting deleted for the following reason: ${reason}
+    
+    Goodbye 👋
+        `.trim(),
+      )
+
+      // Give just a while for the users to understand that the channel will be deleted soon
+      await sleep(3000)
+      await channel.delete(reason)
+      return
+    }
+
+    if (
+      (timeSinceChannelCreation > maxExistingTime - warningStep ||
+        timeSinceLastMessage > maxInactiveTime - warningStep) &&
+      !warnedChannels.has(channel.id)
+    ) {
+      let reason
+      if (timeSinceChannelCreation > maxExistingTime - warningStep) {
+        reason = eolReason
+      } else {
+        reason = inactivityReason
+      }
+      await send(
+        `
+    This channel will be deleted in 5 minutes for the following reason: ${reason}
+        `.trim(),
+      )
+      warnedChannels.add(channel.id)
+    }
+  })
+}
+
+module.exports = {cleanup}

--- a/src/private-chat/index.js
+++ b/src/private-chat/index.js
@@ -1,0 +1,13 @@
+const privateChat = {
+  ...require('./cleanup'),
+}
+
+function setup(client) {
+  setInterval(() => {
+    client.guilds.cache.forEach(guild => {
+      privateChat.cleanup(guild)
+    })
+  }, 5000)
+}
+
+module.exports = {...privateChat, setup}

--- a/src/utils.js
+++ b/src/utils.js
@@ -4,6 +4,9 @@ const sleep = t =>
     setTimeout(resolve, process.env.NODE_ENV === 'test' ? 0 : t),
   )
 
+const privateChannelPrefix =
+  process.env.NODE_ENV === 'production' ? '🤫-private-' : '😎-private-'
+
 const welcomeChannelPrefix =
   process.env.NODE_ENV === 'production' ? '👋-welcome-' : '🌊-welcome-'
 
@@ -104,4 +107,5 @@ module.exports = {
   getMessageLink,
   isWelcomeChannel,
   welcomeChannelPrefix,
+  privateChannelPrefix,
 }


### PR DESCRIPTION
fix #13 

**What**: I have added the new awesome command. I'm not pretty sure about two things 
1) Texts in general 😜. My english is not the best
2) The naming convention used for the channel

**Why**: Because `discord` doesn't have threads. This new command is not like a thread but can help members to move on a new chat when discussing on something

**How**: The new command is available as ?private-chat.
Members can create new channels using this command, but can be only one channel active for the same members.
The channel will be created under a category called `PRIVATE CHAT`. 
After 10 minutes of inactivity or after 1 hour the chat will be deleted. There is also a warning message 5 minutes before delete.

About testing, I think that testing the bot should be pretty simple. For the `cleanup` should be a little bit complicate 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
