### PR TITLE
feat: show rank for thanked users

### DIFF
--- a/src/commands/command-fns/thanks.js
+++ b/src/commands/command-fns/thanks.js
@@ -81,7 +81,7 @@ async function thanks(message) {
   let thanksHistory
   try {
     thanksHistory = await getThanksHistory()
-  } catch (_) {
+  } catch {
     return message.channel.send(
       `There is an issue retrying the history. Please try again later 👎`,
     )
@@ -121,14 +121,16 @@ ${topUsers
     }
 
     return message.channel.send(
-      `This is the rank of the requested members : 
+      `This is the rank of the requested member${
+        searchedMembers.length === 1 ? '' : 's'
+      }: 
 ${searchedMembers
   .map(member => {
     return thanksHistory[member.id]
       ? `- ${member.username} has been thanked ${
           thanksHistory[member.id]
         } times 👏`
-      : `- ${member.username} has never been thanked 🙁`
+      : `- ${member.username} hasn't been thanked yet 🙁`
   })
   .join('\n')}`,
     )

--- a/src/commands/command-fns/thanks.js
+++ b/src/commands/command-fns/thanks.js
@@ -117,7 +117,7 @@ async function thanks(message) {
     thanksHistory = await getThanksHistory()
   } catch {
     return message.channel.send(
-      `There is an issue retrieving the history. Please try again later 👎`,
+      `There is an issue retrieving the history. Please try again later 🙏`,
     )
   }
 

--- a/src/commands/command-fns/thanks.js
+++ b/src/commands/command-fns/thanks.js
@@ -156,20 +156,25 @@ ${topUsers
       searchedMembers = mentionedMembers.map(member => member.user)
     }
 
-    return message.channel.send(
-      `This is the rank of the requested member${
-        searchedMembers.length === 1 ? '' : 's'
-      }: 
-${searchedMembers
+const rankings = searchedMembers
   .map(member => {
-    return thanksHistory[member.id]
-      ? `- ${member.username} has been thanked ${
-          thanksHistory[member.id].length
-        } times 👏`
+    const thanks = thanksHistory[member.id]
+    return thanks
+      ? `- ${member.username} has been thanked ${thanks.length} time${
+          thanks.length === 1 ? '' : 's'
+        } 👏`
       : `- ${member.username} hasn't been thanked yet 🙁`
   })
-  .join('\n')}`,
-    )
+  .join('\n')
+
+message.channel.send(
+  `
+This is the rank of the requested member${
+    searchedMembers.length === 1 ? '' : 's'
+  }: 
+${rankings}
+  `.trim(),
+)
   } else {
     return sayThankYou(args, message, thanksHistory)
   }

--- a/src/commands/command-fns/thanks.js
+++ b/src/commands/command-fns/thanks.js
@@ -7,10 +7,11 @@ const {
   getMember,
   getChannel,
   getMessageLink,
+  getThanksHistory,
+  saveThanksHistory,
 } = require('../utils')
 
-async function thanks(message) {
-  const args = getCommandArgs(message.content)
+async function sayThankyou(args, message, thanksHistory) {
   const member = getMember(message.guild, message.author.id)
   const thankedMembers = Array.from(message.mentions.members.values())
   if (!thankedMembers.length) {
@@ -27,6 +28,23 @@ async function thanks(message) {
       `You have to use the word "for" when thanking someone. ${example}`,
     )
   }
+
+  thankedMembers.forEach(thankedMember => {
+    if (thanksHistory[thankedMember.id]) {
+      thanksHistory[thankedMember.id] += 1
+    } else {
+      thanksHistory[thankedMember.id] = 1
+    }
+  })
+
+  try {
+    await saveThanksHistory(thanksHistory)
+  } catch (_) {
+    return message.channel.send(
+      `There is an issue saving the history. Please try again later`,
+    )
+  }
+
   const thanksMessage = args
     .replace(MessageMentions.USERS_PATTERN, '')
     .replace(/^.*?for/, '')
@@ -55,11 +73,82 @@ Link: <${messageLink}>
   )
   return result
 }
+
+async function thanks(message) {
+  const args = getCommandArgs(message.content)
+  const rankArgs = args.replace(MessageMentions.USERS_PATTERN, '').trim()
+
+  let thanksHistory
+  try {
+    thanksHistory = await getThanksHistory()
+  } catch (_) {
+    return message.channel.send(
+      `There is an issue retrying the history. Please try again later 👎`,
+    )
+  }
+
+  const rankArgumentList = rankArgs.split(' ')
+  if (
+    rankArgumentList.length === 2 &&
+    rankArgumentList[0] === 'rank' &&
+    rankArgumentList[1] === 'top'
+  ) {
+    const sortedUsers = Object.keys(thanksHistory).sort((a, b) => {
+      return thanksHistory[b] - thanksHistory[a]
+    })
+    const topUsers = []
+    await sortedUsers.forEach(async user => {
+      const member = await message.guild.members.fetch(user)
+      if (member) {
+        topUsers.push(member.user)
+      }
+    })
+    return message.channel.send(
+      `This is the list of the top thanked members 💪🏼:
+${topUsers
+  .map(
+    user =>
+      `- ${user.username} has been thanked  ${thanksHistory[user.id]} times 👏`,
+  )
+  .join('\n')}
+`,
+    )
+  } else if (rankArgumentList.length === 1 && rankArgumentList[0] === 'rank') {
+    const mentionedMembers = Array.from(message.mentions.members.values())
+    let searchedMembers = [message.author]
+    if (mentionedMembers.length > 0) {
+      searchedMembers = mentionedMembers.map(member => member.user)
+    }
+
+    return message.channel.send(
+      `This is the rank of the requested members : 
+${searchedMembers
+  .map(member => {
+    return thanksHistory[member.id]
+      ? `- ${member.username} has been thanked ${
+          thanksHistory[member.id]
+        } times 👏`
+      : `- ${member.username} has never been thanked 🙁`
+  })
+  .join('\n')}`,
+    )
+  } else {
+    return sayThankyou(args, message, thanksHistory)
+  }
+}
+
 thanks.description = `A special way to show your appreciation for someone who's helped you out a bit`
 thanks.help = async message => {
   const thanksChannel = getChannel(message.guild, {name: 'thank-you'})
+
+  const commandsList = [
+    `- Send \`?thanks @UserName for answering my question about which socks I should wear and being so polite.\` (for example), and your thanks will appear in the ${thanksChannel}.`,
+    `- Send \`?thanks rank\` to show the number of times you have been thanked.`,
+    `- Send \`?thanks rank top\` to show the top 10 users.`,
+    `- Send \`?thanks rank @Username\` to show the number of times have been thanked the mentioned users.`,
+  ]
   await message.channel.send(
-    `Send \`?thanks @UserName for answering my question about which socks I should wear and being so polite.\` (for example), and your thanks will appear in the ${thanksChannel}`,
+    `This is the list of the available commands \n ${commandsList.join('\n')}`,
   )
 }
 

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,4 @@
+const got = require('got')
 const rollbar = require('./rollbar')
 const sleep = t =>
   new Promise(resolve =>
@@ -60,6 +61,43 @@ function getRole(guild, {name}) {
   )
 }
 
+async function getThanksHistory() {
+  const response = await got.get(
+    `https://api.github.com/gists/${process.env.GIST_REPO_THANKS}`,
+    {
+      headers: {
+        Authorization: `token ${process.env.GITHUB_TOKEN}`,
+      },
+      responseType: 'json',
+    },
+  )
+  if (response.body.files['thanks.json'].content === '') {
+    return {}
+  }
+  return JSON.parse(response.body.files['thanks.json'].content)
+}
+
+async function saveThanksHistory(history) {
+  const body = {
+    public: 'false',
+    files: {
+      'thanks.json': {
+        content: JSON.stringify(history),
+      },
+    },
+  }
+  await got.patch(
+    `https://api.github.com/gists/${process.env.GIST_REPO_THANKS}`,
+    {
+      json: body,
+      headers: {
+        Authorization: `token ${process.env.GITHUB_TOKEN}`,
+      },
+      responseType: 'json',
+    },
+  )
+}
+
 const prodRegex = /^\?(?<command>\S+?)($| )(?<args>(.|\n)*)/
 const devRegex = /^~(?<command>\S+?)($| )(?<args>(.|\n)*)/
 const commandPrefix =
@@ -108,4 +146,6 @@ module.exports = {
   isWelcomeChannel,
   welcomeChannelPrefix,
   privateChannelPrefix,
+  getThanksHistory,
+  saveThanksHistory,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,4 +1,3 @@
-const got = require('got')
 const rollbar = require('./rollbar')
 const sleep = t =>
   new Promise(resolve =>
@@ -61,43 +60,6 @@ function getRole(guild, {name}) {
   )
 }
 
-async function getThanksHistory() {
-  const response = await got.get(
-    `https://api.github.com/gists/${process.env.GIST_REPO_THANKS}`,
-    {
-      headers: {
-        Authorization: `token ${process.env.GITHUB_TOKEN}`,
-      },
-      responseType: 'json',
-    },
-  )
-  if (response.body.files['thanks.json'].content === '') {
-    return {}
-  }
-  return JSON.parse(response.body.files['thanks.json'].content)
-}
-
-async function saveThanksHistory(history) {
-  const body = {
-    public: 'false',
-    files: {
-      'thanks.json': {
-        content: JSON.stringify(history),
-      },
-    },
-  }
-  await got.patch(
-    `https://api.github.com/gists/${process.env.GIST_REPO_THANKS}`,
-    {
-      json: body,
-      headers: {
-        Authorization: `token ${process.env.GITHUB_TOKEN}`,
-      },
-      responseType: 'json',
-    },
-  )
-}
-
 const prodRegex = /^\?(?<command>\S+?)($| )(?<args>(.|\n)*)/
 const devRegex = /^~(?<command>\S+?)($| )(?<args>(.|\n)*)/
 const commandPrefix =
@@ -146,6 +108,4 @@ module.exports = {
   isWelcomeChannel,
   welcomeChannelPrefix,
   privateChannelPrefix,
-  getThanksHistory,
-  saveThanksHistory,
 }


### PR DESCRIPTION

**What**: I have added a score for users receiving thanks as for comment https://github.com/kentcdodds/kcd-discord-bot/issues/11#issuecomment-701479051

<!-- Why are these changes necessary? -->

**Why**: Is cool to have this kind of feature

**How**: 
Each score score is saved on gist. The score is simply a counter of how many thanks has received an user.
To make this possible I have aded two new env variables:
1. `GITHUB_TOKEN` that is used to make http request to gist
2. `GIST_REPO_THANKS` the id the the repo gist

The repo should have a file called `thanks.json`

The command `?thanks` has know more subcommands

1. Send `?thanks @UserName for answering my question about which socks I should wear and being so polite.
2. Send `?thanks rank` to show the number of times you have been thanked.
3. Send `?thanks rank top` to show the top 10 users.
4. Send `?thanks rank @Username` to show the number of times have been thanked the mentioned users.

It is a base implementation of the score. Let me know what do you think 😄 
  

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
