### PR TITLE
fix: listify members

### DIFF
--- a/src/commands/command-fns/private-chat.js
+++ b/src/commands/command-fns/private-chat.js
@@ -89,7 +89,7 @@ async function privateChat(message) {
   )
   await channel.send(
     `
-Hello ${listify(mentionedMembersNicknames)} 👋
+Hello ${listify(mentionedMembers, {stringify: member => member})} 👋
 
 I'm a bot I have created this channel for you. The channel will be deleted after 1 hour or after 10 minutes for inactivity. Enjoy 🗣 
 

--- a/src/commands/command-fns/private-chat.js
+++ b/src/commands/command-fns/private-chat.js
@@ -87,10 +87,9 @@ async function privateChat(message) {
       ],
     },
   )
-
   await channel.send(
     `
-Hello ${listify(mentionedMembers)} 👋
+Hello ${listify(mentionedMembersNicknames)} 👋
 
 I'm a bot I have created this channel for you. The channel will be deleted after 1 hour or after 10 minutes for inactivity. Enjoy 🗣 
 


### PR DESCRIPTION
Thanks to the community for the report

<!-- What changes are being made? (What feature/bug is being fixed here?) -->

**What**:  When the new channel is created, the welcome message showed a wrong text

**Why**: to fix a bug

**How**: use as `stringify` function a function that return the member without stringify it 

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [ ] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
