### PR TITLE
tests: add private chat tests and improve tests with Discord

### DIFF
--- a/src/__tests__/onboarding.js
+++ b/src/__tests__/onboarding.js
@@ -1,85 +1,10 @@
 const Discord = require('discord.js')
 const {rest} = require('msw')
-const {setupServer} = require('msw/node')
+const {server} = require('server')
+
 const {
   onboarding: {handleNewMember, handleNewMessage, handleUpdatedMessage},
 } = require('..')
-
-const server = setupServer(
-  rest.get('https://api.convertkit.com/v3/subscribers', (req, res, ctx) => {
-    return res(
-      ctx.json({
-        total_subscribers: 0,
-        page: 1,
-        total_pages: 1,
-        subscribers: [],
-      }),
-    )
-  }),
-  rest.post(
-    'https://api.convertkit.com/v3/forms/:formId/subscribe',
-    (req, res, ctx) => {
-      const {formId} = req.params
-      const {first_name, email, fields} = req.body
-      return res(
-        ctx.json({
-          subscription: {
-            id: 1234567890,
-            state: 'active',
-            created_at: new Date().toJSON(),
-            source: 'API::V3::SubscriptionsController (external)',
-            referrer: null,
-            subscribable_id: formId,
-            subscribable_type: 'form',
-            subscriber: {
-              id: 987654321,
-              first_name,
-              email_address: email,
-              state: 'inactive',
-              created_at: new Date().toJSON(),
-              fields,
-            },
-          },
-        }),
-      )
-    },
-  ),
-  rest.post(
-    'https://api.convertkit.com/v3/tags/:tagId/subscribe',
-    (req, res, ctx) => {
-      const {tagId} = req.params
-      const {first_name, email, fields} = req.body
-      return res(
-        ctx.json({
-          subscription: {
-            id: 1234567890,
-            state: 'active',
-            created_at: new Date().toJSON(),
-            source: 'API::V3::SubscriptionsController (external)',
-            referrer: null,
-            subscribable_id: tagId,
-            subscribable_type: 'tag',
-            subscriber: {
-              id: 987654321,
-              first_name,
-              email_address: email,
-              state: 'inactive',
-              created_at: new Date().toJSON(),
-              fields,
-            },
-          },
-        }),
-      )
-    },
-  ),
-  rest.get('https://www.gravatar.com/avatar/:hash', (req, res, ctx) => {
-    return res(ctx.status(200))
-  }),
-)
-
-beforeAll(() => server.listen({onUnhandledRequest: 'error'}))
-afterAll(() => server.close())
-afterEach(() => server.resetHandlers())
 
 // eslint-disable-next-line max-lines-per-function
 async function setup() {

--- a/src/__tests__/onboarding.js
+++ b/src/__tests__/onboarding.js
@@ -58,6 +58,7 @@ async function setup() {
   function getMessageThread() {
     return `
 Messages in ${onboardingChannel.name}
+
 ${Array.from(onboardingChannel.messages.cache.values())
   .map(m => {
     const content = m.content
@@ -186,6 +187,7 @@ test('the typical flow', async () => {
 
   expect(getMessageThread()).toMatchInlineSnapshot(`
     "Messages in 🌊-welcome-fredjoe_1234
+    
     BOT: Hello <@mock-user> 👋
 
     I'm a bot and I'm here to welcome you to the KCD Community on Discord! Before you can join in the fun, I need to ask you a few questions. If you have any trouble, please email team@kentcdodds.com with your discord username (\`fredjoe#1234\`), an explanation of the trouble, and a screenshot of the conversation. And we'll get things fixed up for you.
@@ -375,6 +377,7 @@ test('typing and editing to an invalid value', async () => {
 
   expect(getMessageThread()).toMatchInlineSnapshot(`
     "Messages in 🌊-welcome-fredjoe_1234
+    
     BOT: Hello <@mock-user> 👋
 
     I'm a bot and I'm here to welcome you to the KCD Community on Discord! Before you can join in the fun, I need to ask you a few questions. If you have any trouble, please email team@kentcdodds.com with your discord username (\`fredjoe#1234\`), an explanation of the trouble, and a screenshot of the conversation. And we'll get things fixed up for you.
@@ -492,6 +495,7 @@ test('a new member with some info already', async () => {
 
   expect(getMessageThread()).toMatchInlineSnapshot(`
     "Messages in 🌊-welcome-fredjoe_1234
+    
     BOT: Hello <@mock-user> 👋
 
     I'm a bot and I'm here to welcome you to the KCD Community on Discord! Before you can join in the fun, I need to ask you a few questions. If you have any trouble, please email team@kentcdodds.com with your discord username (\`fredjoe#1234\`), an explanation of the trouble, and a screenshot of the conversation. And we'll get things fixed up for you.

--- a/src/__tests__/onboarding.js
+++ b/src/__tests__/onboarding.js
@@ -121,6 +121,10 @@ test('the typical flow', async () => {
     member,
   } = await setup()
 
+  expect(onboardingChannel.name).toMatchInlineSnapshot(
+    `"🌊-welcome-fredjoe_1234"`,
+  )
+
   const name = 'Fred'
   const email = 'fred@example.com'
   await send(name) // What's your name

--- a/src/commands/__tests__/index.js
+++ b/src/commands/__tests__/index.js
@@ -3,7 +3,7 @@ const {makeFakeClient} = require('test-utils')
 const {handleNewMessage} = require('..')
 
 test('handles incoming messages', async () => {
-  const {client, talkToBotsChannel, kody} = makeFakeClient()
+  const {client, talkToBotsChannel, kody} = await makeFakeClient()
 
   const message = new Discord.Message(
     client,

--- a/src/commands/__tests__/index.js
+++ b/src/commands/__tests__/index.js
@@ -1,5 +1,5 @@
 const Discord = require('discord.js')
-const {makeFakeClient} = require('test-utils')
+const {makeFakeClient, waitUntil} = require('test-utils')
 const {handleNewMessage} = require('..')
 
 test('handles incoming messages', async () => {
@@ -12,5 +12,22 @@ test('handles incoming messages', async () => {
   )
 
   await handleNewMessage(message)
-  expect(talkToBotsChannel.send).toHaveBeenCalledTimes(1)
+  await waitUntil(() =>
+    expect(Array.from(talkToBotsChannel.messages.cache.values())).toHaveLength(
+      1,
+    ),
+  )
+  const messages = Array.from(talkToBotsChannel.messages.cache.values())
+  expect(messages[0].content).toMatchInlineSnapshot(`
+    "Here are the available commands:
+
+    - help: Lists available commands
+    - kif: Send a KCD gif (send \`?help kif\` for more info)
+    - thanks: A special way to show your appreciation for someone who's helped you out a bit
+    - roles: Add or remove yourself from these roles: \\"Notify: Kent Live\\" and \\"Notify: Office Hours\\"
+    - clubs: Create a club with \`?clubs create LINK_TO_GOOGLE_FORM\` (learn more: <https://kcd.im/clubs>)
+    - info: Gives information about the bot (deploy date etc.)
+    - private-chat: Create a private channel with who you want. This channel is temporary.
+    - blog: Find articles on Kent's blog: <https://kentcdodds.com/blog>"
+  `)
 })

--- a/src/commands/__tests__/index.js
+++ b/src/commands/__tests__/index.js
@@ -3,21 +3,23 @@ const {makeFakeClient, waitUntil} = require('test-utils')
 const {handleNewMessage} = require('..')
 
 test('handles incoming messages', async () => {
-  const {client, talkToBotsChannel, kody} = await makeFakeClient()
+  const {client, defaultChannels, kody} = await makeFakeClient()
 
   const message = new Discord.Message(
     client,
     {id: 'help_test', content: '?help', author: kody.user},
-    talkToBotsChannel,
+    defaultChannels.talkToBotsChannel,
   )
 
   await handleNewMessage(message)
   await waitUntil(() =>
-    expect(Array.from(talkToBotsChannel.messages.cache.values())).toHaveLength(
-      1,
-    ),
+    expect(
+      Array.from(defaultChannels.talkToBotsChannel.messages.cache.values()),
+    ).toHaveLength(1),
   )
-  const messages = Array.from(talkToBotsChannel.messages.cache.values())
+  const messages = Array.from(
+    defaultChannels.talkToBotsChannel.messages.cache.values(),
+  )
   expect(messages[0].content).toMatchInlineSnapshot(`
     "Here are the available commands:
 

--- a/src/commands/command-fns/__tests__/blog.js
+++ b/src/commands/command-fns/__tests__/blog.js
@@ -5,7 +5,7 @@ const {makeFakeClient} = require('test-utils')
 const blog = require('../blog')
 
 const setup = async command => {
-  const {client, talkToBotsChannel, kody, cleanup} = await makeFakeClient()
+  const {client, defaultChannels, kody, cleanup} = await makeFakeClient()
   const message = new Discord.Message(
     client,
     {
@@ -13,14 +13,16 @@ const setup = async command => {
       content: `?blog ${command}`,
       author: kody.user,
     },
-    talkToBotsChannel,
+    defaultChannels.talkToBotsChannel,
   )
   Object.assign(message, {
     mentions: new Discord.MessageMentions(message, [], [], false),
   })
   await blog(message)
 
-  const messages = Array.from(talkToBotsChannel.messages.cache.values())
+  const messages = Array.from(
+    defaultChannels.talkToBotsChannel.messages.cache.values(),
+  )
   return {messages, cleanup}
 }
 

--- a/src/commands/command-fns/__tests__/blog.js
+++ b/src/commands/command-fns/__tests__/blog.js
@@ -27,6 +27,7 @@ const setup = async command => {
 test('should show the list of the last 10 articles', async () => {
   const {messages} = await setup('last')
 
+  expect(messages).toHaveLength(1)
   expect(messages[0].content).toMatchInlineSnapshot(`
     "This is the list of the last 10 articles on the blog:
     - How to React ⚛️
@@ -55,6 +56,7 @@ test('should show the list of the last 10 articles', async () => {
 test('should show articles matching the search string', async () => {
   let utils = await setup('open source')
 
+  expect(utils.messages).toHaveLength(1)
   expect(utils.messages[0].content).toMatchInlineSnapshot(`
     "This is the list of the articles matching \\"open source\\" 💻:
     - Favor Progress Over Pride in Open Source
@@ -68,6 +70,7 @@ test('should show articles matching the search string', async () => {
   utils.cleanup()
   utils = await setup('onditionally render content in JSX')
 
+  expect(utils.messages).toHaveLength(1)
   expect(utils.messages[0].content).toEqual(
     `https://kentcdodds.com/blog/use-ternaries-rather-than-and-and-in-jsx`,
   )
@@ -75,21 +78,25 @@ test('should show articles matching the search string', async () => {
 
   utils = await setup(`why you shouldn't mock fetch or your AP`)
 
+  expect(utils.messages).toHaveLength(1)
   expect(utils.messages[0].content).toEqual(
     `https://kentcdodds.com/blog/stop-mocking-fetch`,
   )
 })
 
 test('should show the first articles retrieved', async () => {
-  const send = await setup(`latest`)
+  const {messages} = await setup(`latest`)
 
-  expect(send).toHaveBeenCalledTimes(1)
-  expect(send).toHaveBeenCalledWith(`https://kentcdodds.com/blog/how-to-react`)
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toEqual(
+    `https://kentcdodds.com/blog/how-to-react`,
+  )
 })
 
 test('should show an info message if not articles are found', async () => {
   const {messages} = await setup(`not exist`)
 
+  expect(messages).toHaveLength(1)
   expect(messages[0].content).toMatchInlineSnapshot(
     `"Unfortunately there is no article matching \\"not exist\\" 😟. Try searching here: <https://kentcdodds.com/blog>"`,
   )
@@ -104,6 +111,7 @@ test('should show an info message if there is an issue retrying articles', async
 
   const {messages} = await setup(`not exist`)
 
+  expect(messages).toHaveLength(1)
   expect(messages[0].content).toMatchInlineSnapshot(
     `"Something went wrong retrieving the list of articles 😬. Try searching here: <https://kentcdodds.com/blog>"`,
   )
@@ -112,6 +120,7 @@ test('should show an info message if there is an issue retrying articles', async
 test('should give an error message if the user not provide a search term', async () => {
   const {messages} = await setup(``)
 
+  expect(messages).toHaveLength(1)
   expect(messages[0].content).toEqual(
     `A search term is required. For example: \`?blog state management\``,
   )

--- a/src/commands/command-fns/__tests__/blog.js
+++ b/src/commands/command-fns/__tests__/blog.js
@@ -5,7 +5,7 @@ const {makeFakeClient} = require('test-utils')
 const blog = require('../blog')
 
 const setup = async command => {
-  const {client, talkToBotsChannel, kody} = makeFakeClient()
+  const {client, talkToBotsChannel, kody} = await makeFakeClient()
   const message = new Discord.Message(
     client,
     {

--- a/src/commands/command-fns/__tests__/blog.js
+++ b/src/commands/command-fns/__tests__/blog.js
@@ -123,7 +123,36 @@ test('should give an error message if the user not provide a search term', async
   const {messages} = await setup(``)
 
   expect(messages).toHaveLength(1)
-  expect(messages[0].content).toEqual(
-    `A search term is required. For example: \`?blog state management\``,
+  expect(messages[0].content).toMatchInlineSnapshot(
+    `"A search term is required. For example: \`?blog state management\`"`,
   )
+})
+
+test('should show the first 10 results if there are more', async () => {
+  const {messages} = await setup(`re`)
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toMatchInlineSnapshot(`
+    "There are too many results for \\"re\\". Here are the top 10:
+    - Use react-error-boundary to handle errors in React
+      <https://kentcdodds.com/blog/use-react-error-boundary-to-handle-errors-in-react>
+    - How to React ⚛️
+      <https://kentcdodds.com/blog/how-to-react>
+    - useState lazy initialization and function updates
+      <https://kentcdodds.com/blog/use-state-lazy-initialization-and-function-updates>
+    - Use ternaries rather than && in JSX
+      <https://kentcdodds.com/blog/use-ternaries-rather-than-and-and-in-jsx>
+    - Application State Management with React
+      <https://kentcdodds.com/blog/application-state-management-with-react>
+    - JavaScript to Know for React
+      <https://kentcdodds.com/blog/javascript-to-know-for-react>
+    - 💯 UPDATED: Advanced React Component Patterns ⚛️
+      <https://kentcdodds.com/blog/updated-advanced-react-component-patterns>
+    - Testing Implementation Details
+      <https://kentcdodds.com/blog/testing-implementation-details>
+    - How I Record Educational Videos
+      <https://kentcdodds.com/blog/how-i-record-educational-videos>
+    - Should I write a test or fix a bug?
+      <https://kentcdodds.com/blog/should-i-write-a-test-or-fix-a-bug>"
+  `)
 })

--- a/src/commands/command-fns/__tests__/help.js
+++ b/src/commands/command-fns/__tests__/help.js
@@ -10,10 +10,21 @@ test('prints help for all commands', async () => {
     talkToBotsChannel,
   )
   await help(message)
-  expect(talkToBotsChannel.send).toHaveBeenCalledWith(
-    expect.stringContaining('- help'),
-  )
-  expect(talkToBotsChannel.send).toHaveBeenCalledTimes(1)
+
+  const messages = Array.from(talkToBotsChannel.messages.cache.values())
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toMatchInlineSnapshot(`
+    "Here are the available commands:
+
+    - help: Lists available commands
+    - kif: Send a KCD gif (send \`?help kif\` for more info)
+    - thanks: A special way to show your appreciation for someone who's helped you out a bit
+    - roles: Add or remove yourself from these roles: \\"Notify: Kent Live\\" and \\"Notify: Office Hours\\"
+    - clubs: Create a club with \`?clubs create LINK_TO_GOOGLE_FORM\` (learn more: <https://kcd.im/clubs>)
+    - info: Gives information about the bot (deploy date etc.)
+    - private-chat: Create a private channel with who you want. This channel is temporary.
+    - blog: Find articles on Kent's blog: <https://kentcdodds.com/blog>"
+  `)
 })
 
 test('help with a specific command', async () => {
@@ -24,8 +35,10 @@ test('help with a specific command', async () => {
     talkToBotsChannel,
   )
   await help(message)
-  expect(talkToBotsChannel.send).toHaveBeenCalledWith(
-    expect.stringContaining('information'),
+
+  const messages = Array.from(talkToBotsChannel.messages.cache.values())
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toMatchInlineSnapshot(
+    `"Gives information about the bot (deploy date etc.)"`,
   )
-  expect(talkToBotsChannel.send).toHaveBeenCalledTimes(1)
 })

--- a/src/commands/command-fns/__tests__/help.js
+++ b/src/commands/command-fns/__tests__/help.js
@@ -3,15 +3,17 @@ const {makeFakeClient} = require('test-utils')
 const help = require('../help')
 
 test('prints help for all commands', async () => {
-  const {client, talkToBotsChannel} = await makeFakeClient()
+  const {client, defaultChannels} = await makeFakeClient()
   const message = new Discord.Message(
     client,
     {id: 'help_test', content: '?help'},
-    talkToBotsChannel,
+    defaultChannels.talkToBotsChannel,
   )
   await help(message)
 
-  const messages = Array.from(talkToBotsChannel.messages.cache.values())
+  const messages = Array.from(
+    defaultChannels.talkToBotsChannel.messages.cache.values(),
+  )
   expect(messages).toHaveLength(1)
   expect(messages[0].content).toMatchInlineSnapshot(`
     "Here are the available commands:
@@ -28,15 +30,17 @@ test('prints help for all commands', async () => {
 })
 
 test('help with a specific command', async () => {
-  const {client, talkToBotsChannel} = await makeFakeClient()
+  const {client, defaultChannels} = await makeFakeClient()
   const message = new Discord.Message(
     client,
     {id: 'help_test', content: '?help info'},
-    talkToBotsChannel,
+    defaultChannels.talkToBotsChannel,
   )
   await help(message)
 
-  const messages = Array.from(talkToBotsChannel.messages.cache.values())
+  const messages = Array.from(
+    defaultChannels.talkToBotsChannel.messages.cache.values(),
+  )
   expect(messages).toHaveLength(1)
   expect(messages[0].content).toMatchInlineSnapshot(
     `"Gives information about the bot (deploy date etc.)"`,

--- a/src/commands/command-fns/__tests__/help.js
+++ b/src/commands/command-fns/__tests__/help.js
@@ -3,7 +3,7 @@ const {makeFakeClient} = require('test-utils')
 const help = require('../help')
 
 test('prints help for all commands', async () => {
-  const {client, talkToBotsChannel} = makeFakeClient()
+  const {client, talkToBotsChannel} = await makeFakeClient()
   const message = new Discord.Message(
     client,
     {id: 'help_test', content: '?help'},
@@ -17,7 +17,7 @@ test('prints help for all commands', async () => {
 })
 
 test('help with a specific command', async () => {
-  const {client, talkToBotsChannel} = makeFakeClient()
+  const {client, talkToBotsChannel} = await makeFakeClient()
   const message = new Discord.Message(
     client,
     {id: 'help_test', content: '?help info'},

--- a/src/commands/command-fns/__tests__/info.js
+++ b/src/commands/command-fns/__tests__/info.js
@@ -42,7 +42,10 @@ test('prints useful info', async () => {
   )
 
   await info(message)
-  expect(talkToBotsChannel.send.mock.calls[0][0]).toMatchInlineSnapshot(`
+
+  const messages = Array.from(talkToBotsChannel.messages.cache.values())
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toMatchInlineSnapshot(`
     "Here's some info about the currently running bot:
 
       Started at: Wed, 21 Oct 2020 07:20:15 GMT (now)
@@ -53,5 +56,4 @@ test('prints useful info', async () => {
         message: improve the info command
         link: <https://github.com/kentcdodds/kcd-discord-bot/commit/b84d60ca5507ebf73c8fd2fe620a8ad1cdf1958e>"
   `)
-  expect(talkToBotsChannel.send).toHaveBeenCalledTimes(1)
 })

--- a/src/commands/command-fns/__tests__/info.js
+++ b/src/commands/command-fns/__tests__/info.js
@@ -34,16 +34,18 @@ afterEach(() => {
 
 test('prints useful info', async () => {
   const info = require('../info')
-  const {client, talkToBotsChannel, kody} = await makeFakeClient()
+  const {client, defaultChannels, kody} = await makeFakeClient()
   const message = new Discord.Message(
     client,
     {id: 'help_test', content: '?info', author: kody.user},
-    talkToBotsChannel,
+    defaultChannels.talkToBotsChannel,
   )
 
   await info(message)
 
-  const messages = Array.from(talkToBotsChannel.messages.cache.values())
+  const messages = Array.from(
+    defaultChannels.talkToBotsChannel.messages.cache.values(),
+  )
   expect(messages).toHaveLength(1)
   expect(messages[0].content).toMatchInlineSnapshot(`
     "Here's some info about the currently running bot:

--- a/src/commands/command-fns/__tests__/info.js
+++ b/src/commands/command-fns/__tests__/info.js
@@ -34,7 +34,7 @@ afterEach(() => {
 
 test('prints useful info', async () => {
   const info = require('../info')
-  const {client, talkToBotsChannel, kody} = makeFakeClient()
+  const {client, talkToBotsChannel, kody} = await makeFakeClient()
   const message = new Discord.Message(
     client,
     {id: 'help_test', content: '?info', author: kody.user},

--- a/src/commands/command-fns/__tests__/kif.js
+++ b/src/commands/command-fns/__tests__/kif.js
@@ -45,6 +45,37 @@ test('suggests similar item', async () => {
   `)
 })
 
+test('should use username in the from if nickname is not defined', async () => {
+  const {client, defaultChannels, createUser} = await makeFakeClient()
+  const userWithOnlyUsername = await createUser(null, {
+    username: 'userWithOnlyUsername',
+  })
+  const message = new Discord.Message(
+    client,
+    {
+      id: 'help_test',
+      content: '?kif peace fail',
+      author: userWithOnlyUsername.user,
+    },
+    defaultChannels.talkToBotsChannel,
+  )
+  Object.assign(message, {
+    mentions: new Discord.MessageMentions(message, [], [], false),
+  })
+  await kif(message)
+
+  const messages = Array.from(
+    defaultChannels.talkToBotsChannel.messages.cache.values(),
+  )
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toMatchInlineSnapshot(`
+    "Did you mean \\"peace fall\\"?
+    From: userWithOnlyUsername
+    https://giphy.com/gifs/fall-peace-kentcdodds-U3nGECxxmHugNeAm6n"
+  `)
+})
+
 test('suggests two items', async () => {
   const {messages} = await setup('?kif peac')
 

--- a/src/commands/command-fns/__tests__/kif.js
+++ b/src/commands/command-fns/__tests__/kif.js
@@ -2,8 +2,8 @@ const Discord = require('discord.js')
 const {makeFakeClient} = require('test-utils')
 const kif = require('../kif')
 
-function getMessage(content) {
-  const {client, talkToBotsChannel, kody} = makeFakeClient()
+async function getMessage(content) {
+  const {client, talkToBotsChannel, kody} = await makeFakeClient()
   const message = new Discord.Message(
     client,
     {
@@ -20,7 +20,7 @@ function getMessage(content) {
 }
 
 test('sends a gif', async () => {
-  const message = getMessage('?kif hi')
+  const message = await getMessage('?kif hi')
   await kif(message)
   expect(message.channel.send.mock.calls[0][0]).toMatchInlineSnapshot(`
     "From: kody
@@ -30,7 +30,7 @@ test('sends a gif', async () => {
 })
 
 test('suggests similar item', async () => {
-  const message = getMessage('?kif peace fail')
+  const message = await getMessage('?kif peace fail')
   await kif(message)
   expect(message.channel.send.mock.calls[0][0]).toMatchInlineSnapshot(`
     "Did you mean \\"peace fall\\"?
@@ -41,7 +41,7 @@ test('suggests similar item', async () => {
 })
 
 test('suggests two items', async () => {
-  const message = getMessage('?kif peac')
+  const message = await getMessage('?kif peac')
   await kif(message)
   expect(message.channel.send.mock.calls[0][0]).toMatchInlineSnapshot(`
     "Couldn't find a kif for: \\"peac\\"
@@ -52,7 +52,7 @@ test('suggests two items', async () => {
 })
 
 test('suggests several items (but no more than 6)', async () => {
-  const message = getMessage('?kif a')
+  const message = await getMessage('?kif a')
   await kif(message)
   expect(message.channel.send.mock.calls[0][0]).toMatchInlineSnapshot(`
     "Couldn't find a kif for: \\"a\\"
@@ -63,7 +63,7 @@ test('suggests several items (but no more than 6)', async () => {
 })
 
 test(`says it can't find something if it can't`, async () => {
-  const message = getMessage('?kif djskfjdlakfjewoifdjd')
+  const message = await getMessage('?kif djskfjdlakfjewoifdjd')
   await kif(message)
   expect(message.channel.send.mock.calls[0][0]).toMatchInlineSnapshot(
     `"Couldn't find a kif for: \\"djskfjdlakfjewoifdjd\\""`,

--- a/src/commands/command-fns/__tests__/kif.js
+++ b/src/commands/command-fns/__tests__/kif.js
@@ -3,7 +3,7 @@ const {makeFakeClient} = require('test-utils')
 const kif = require('../kif')
 
 async function setup(content) {
-  const {client, talkToBotsChannel, kody} = await makeFakeClient()
+  const {client, defaultChannels, kody} = await makeFakeClient()
   const message = new Discord.Message(
     client,
     {
@@ -11,14 +11,16 @@ async function setup(content) {
       content,
       author: kody.user,
     },
-    talkToBotsChannel,
+    defaultChannels.talkToBotsChannel,
   )
   Object.assign(message, {
     mentions: new Discord.MessageMentions(message, [], [], false),
   })
   await kif(message)
 
-  const messages = Array.from(talkToBotsChannel.messages.cache.values())
+  const messages = Array.from(
+    defaultChannels.talkToBotsChannel.messages.cache.values(),
+  )
   return {messages}
 }
 

--- a/src/commands/command-fns/__tests__/kif.js
+++ b/src/commands/command-fns/__tests__/kif.js
@@ -2,7 +2,7 @@ const Discord = require('discord.js')
 const {makeFakeClient} = require('test-utils')
 const kif = require('../kif')
 
-async function getMessage(content) {
+async function setup(content) {
   const {client, talkToBotsChannel, kody} = await makeFakeClient()
   const message = new Discord.Message(
     client,
@@ -16,57 +16,60 @@ async function getMessage(content) {
   Object.assign(message, {
     mentions: new Discord.MessageMentions(message, [], [], false),
   })
-  return message
+  await kif(message)
+
+  const messages = Array.from(talkToBotsChannel.messages.cache.values())
+  return {messages}
 }
 
 test('sends a gif', async () => {
-  const message = await getMessage('?kif hi')
-  await kif(message)
-  expect(message.channel.send.mock.calls[0][0]).toMatchInlineSnapshot(`
+  const {messages} = await setup('?kif hi')
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toMatchInlineSnapshot(`
     "From: kody
     https://giphy.com/gifs/hi-kentcdodds-VbzmrabLQFE8VbQY3V"
   `)
-  expect(message.channel.send).toHaveBeenCalledTimes(1)
 })
 
 test('suggests similar item', async () => {
-  const message = await getMessage('?kif peace fail')
-  await kif(message)
-  expect(message.channel.send.mock.calls[0][0]).toMatchInlineSnapshot(`
+  const {messages} = await setup('?kif peace fail')
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toMatchInlineSnapshot(`
     "Did you mean \\"peace fall\\"?
     From: kody
     https://giphy.com/gifs/fall-peace-kentcdodds-U3nGECxxmHugNeAm6n"
   `)
-  expect(message.channel.send).toHaveBeenCalledTimes(1)
 })
 
 test('suggests two items', async () => {
-  const message = await getMessage('?kif peac')
-  await kif(message)
-  expect(message.channel.send.mock.calls[0][0]).toMatchInlineSnapshot(`
+  const {messages} = await setup('?kif peac')
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toMatchInlineSnapshot(`
     "Couldn't find a kif for: \\"peac\\"
 
     Did you mean \\"peace\\" or \\"peace fall\\"?"
   `)
-  expect(message.channel.send).toHaveBeenCalledTimes(1)
 })
 
 test('suggests several items (but no more than 6)', async () => {
-  const message = await getMessage('?kif a')
-  await kif(message)
-  expect(message.channel.send.mock.calls[0][0]).toMatchInlineSnapshot(`
+  const {messages} = await setup('?kif a')
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toMatchInlineSnapshot(`
     "Couldn't find a kif for: \\"a\\"
 
     Did you mean \\"aw\\", \\"adorable\\", \\"agree\\", \\"agreed\\", \\"aw shucks\\", or \\"peace\\"?"
   `)
-  expect(message.channel.send).toHaveBeenCalledTimes(1)
 })
 
 test(`says it can't find something if it can't`, async () => {
-  const message = await getMessage('?kif djskfjdlakfjewoifdjd')
-  await kif(message)
-  expect(message.channel.send.mock.calls[0][0]).toMatchInlineSnapshot(
+  const {messages} = await setup('?kif djskfjdlakfjewoifdjd')
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toMatchInlineSnapshot(
     `"Couldn't find a kif for: \\"djskfjdlakfjewoifdjd\\""`,
   )
-  expect(message.channel.send).toHaveBeenCalledTimes(1)
 })

--- a/src/commands/command-fns/__tests__/private-chat.js
+++ b/src/commands/command-fns/__tests__/private-chat.js
@@ -1,16 +1,65 @@
 const Discord = require('discord.js')
-const {makeFakeClient} = require('test-utils')
+const {makeFakeClient, createUser} = require('test-utils')
 const privateChat = require('../private-chat')
+const {getCategory} = require('../../utils')
 
-test('should not create a chat without mentioned member', async () => {
-  const {client, talkToBotsChannel} = makeFakeClient()
+async function createPrivateChat(mentionedUsernames = []) {
+  const {client, talkToBotsChannel, guild} = makeFakeClient()
+  const sentMessageUser = createUser(client, 'sentMessageUser', guild)
   const message = new Discord.Message(
     client,
-    {id: 'private_chat_test', content: '?private-chat @Username1'},
+    {
+      id: 'private_chat_test',
+      content: '?private-chat',
+      author: sentMessageUser,
+    },
     talkToBotsChannel,
   )
+  Object.assign(message, {
+    mentions: new Discord.MessageMentions(
+      message,
+      mentionedUsernames.map(username => createUser(client, username, guild)),
+      [],
+      false,
+    ),
+  })
+
   await privateChat(message)
 
+  return {
+    message,
+    guild,
+  }
+}
+
+test('should create a private chat', async () => {
+  const {message, guild} = await createPrivateChat(['mentionedUser'])
+  expect(message.channel.send).toHaveBeenCalledTimes(1)
+  expect(message.channel.send).toHaveBeenCalledWith(
+    `I've created <#😎-private-mentionedUser-and-others-id> for you folks to talk privately. Cheers!`,
+  )
+
+  const categoryPrivateChat = getCategory(message.guild, {name: 'private chat'})
+  const privateChannels = Array.from(
+    guild.channels.cache
+      .filter(channel => channel.parentID?.id === categoryPrivateChat.id)
+      .values(),
+  )
+  expect(privateChannels).toHaveLength(1)
+  const privateChannel = privateChannels[0]
+  expect(privateChannel.send).toHaveBeenCalledTimes(1)
+  expect(privateChannel.send).toHaveBeenCalledWith(
+    `
+Hello <@!mentionedUser-id> and <@!sentMessageUser-id> 👋
+
+I'm the bot that created this channel for you. The channel will be deleted after 1 hour or after 10 minutes for inactivity. Enjoy 🗣
+
+> Please note that the KCD Discord Server Owners and Admins *can* see this chat. So if you want to be *completely* private, then you'll need to take your communication elsewhere.
+`.trim(),
+  )
+})
+test('should not create a chat without mentioned member', async () => {
+  const {message} = await createPrivateChat()
   expect(message.channel.send).toHaveBeenCalledTimes(1)
   expect(message.channel.send).toHaveBeenCalledWith(
     'You should mention at least one other member.',

--- a/src/commands/command-fns/__tests__/private-chat.js
+++ b/src/commands/command-fns/__tests__/private-chat.js
@@ -19,12 +19,12 @@ async function createPrivateChat(mentionedUsernames = []) {
     {
       id: SnowflakeUtil.generate(),
       content: '?private-chat',
-      author: sentMessageUser,
+      author: sentMessageUser.user,
     },
     talkToBotsChannel,
   )
-  const mentionedUsers = mentionedUsernames.map(username =>
-    createUser(client, username, guild),
+  const mentionedUsers = mentionedUsernames.map(
+    username => createUser(username).user,
   )
   Object.assign(message, {
     mentions: new Discord.MessageMentions(message, mentionedUsers, [], false),
@@ -50,7 +50,7 @@ function getPrivateChannels(guild) {
   )
 }
 
-test('should create a private chat', async () => {
+test('should create a private chat for two users', async () => {
   const {message, guild, channelMembers} = await createPrivateChat([
     'mentionedUser',
   ])
@@ -58,10 +58,13 @@ test('should create a private chat', async () => {
 
   expect(privateChannels).toHaveLength(1)
   const privateChannel = privateChannels[0]
+  expect(privateChannel.name).toEqual(
+    `😎-private-mentionedUser-sentMessageUser`,
+  )
   expect(privateChannel.lastMessage).toBeDefined()
   expect(privateChannel.lastMessage.content).toEqual(
     `
-Hello <@!${channelMembers[1].user.id}> and <@!${channelMembers[0].user.id}> 👋
+Hello <@!${channelMembers[1].id}> and <@${channelMembers[0].id}> 👋
 
 I'm the bot that created this channel for you. The channel will be deleted after 1 hour or after 10 minutes for inactivity. Enjoy 🗣
 
@@ -72,6 +75,21 @@ I'm the bot that created this channel for you. The channel will be deleted after
   expect(message.channel.send).toHaveBeenCalledTimes(1)
   expect(message.channel.send).toHaveBeenCalledWith(
     `I've created <#${privateChannel.id}> for you folks to talk privately. Cheers!`,
+  )
+})
+
+test('should create a private chat for more than two users', async () => {
+  const {guild} = await createPrivateChat([
+    'mentionedUser',
+    'mentionedUser2',
+    'mentionedUser3',
+  ])
+  const privateChannels = getPrivateChannels(guild)
+
+  expect(privateChannels).toHaveLength(1)
+  const privateChannel = privateChannels[0]
+  expect(privateChannel.name).toEqual(
+    `😎-private-mentionedUser-mentionedUser2-and-others`,
   )
 })
 

--- a/src/commands/command-fns/__tests__/private-chat.js
+++ b/src/commands/command-fns/__tests__/private-chat.js
@@ -89,6 +89,8 @@ test('should delete the private chat after 10 minutes of inactivity', async () =
   expect(privateChannel.lastMessage.content).toEqual(
     `This channel will be deleted in 5 minutes for the following reason: deleted for inactivity 🚶‍♀️`,
   )
+  // run this to check that no other warning message are sent
+  await cleanup(guild)
 
   jest.spyOn(Date, 'now').mockImplementation(() => 1598947801000) //10:10:01 UTC+2
 
@@ -123,6 +125,8 @@ test('should delete the private chat after 60 minutes', async () => {
   expect(privateChannel.lastMessage.content).toEqual(
     `This channel will be deleted in 5 minutes for the following reason: deleted for end of life 👻`,
   )
+  // run this to check that no other warning message are sent
+  await cleanup(guild)
 
   jest.spyOn(Date, 'now').mockImplementation(() => 1598950801000) //11:00:01 UTC+2
 

--- a/src/commands/command-fns/__tests__/private-chat.js
+++ b/src/commands/command-fns/__tests__/private-chat.js
@@ -163,3 +163,32 @@ test('should give an error trying to create a chat for the same members', async 
     `There is already a chat for the same members <#${privateChannel.id}>`,
   )
 })
+
+test('should not create a private-chat with yourself', async () => {
+  const {client, talkToBotsChannel, createUser} = await makeFakeClient()
+  const sentMessageUser = createUser('sentMessageUser')
+  const message = new Discord.Message(
+    client,
+    {
+      id: SnowflakeUtil.generate(),
+      content: '?private-chat',
+      author: sentMessageUser,
+    },
+    talkToBotsChannel,
+  )
+  Object.assign(message, {
+    mentions: new Discord.MessageMentions(
+      message,
+      [sentMessageUser],
+      [],
+      false,
+    ),
+  })
+
+  await privateChat(message)
+
+  expect(message.channel.send).toHaveBeenCalledTimes(1)
+  expect(message.channel.send).toHaveBeenCalledWith(
+    `You should mention at least one other member.`,
+  )
+})

--- a/src/commands/command-fns/__tests__/private-chat.js
+++ b/src/commands/command-fns/__tests__/private-chat.js
@@ -1,10 +1,79 @@
 const Discord = require('discord.js')
-const {makeFakeClient, createUser} = require('test-utils')
+const {SnowflakeUtil} = require('discord.js')
+const {makeFakeClient, createUser, guilds} = require('test-utils')
+const {rest} = require('msw')
+const {setupServer} = require('msw/node')
 const privateChat = require('../private-chat')
 const {getCategory} = require('../../utils')
+const {cleanup} = require('../../../private-chat/cleanup')
+
+let channels = {}
+const server = setupServer(
+  rest.post('*/api/:apiVersion/guilds/:guild/channels', (req, res, ctx) => {
+    const createdChannel = {
+      id: SnowflakeUtil.generate(),
+      guild_id: req.params.guild,
+      ...req.body,
+    }
+    channels[createdChannel.id] = {
+      ...createdChannel,
+      messages: [],
+    }
+    return res(ctx.status(200), ctx.json(createdChannel))
+  }),
+  rest.get(
+    '*/api/:apiVersion/channels/:channelId/messages',
+    (req, res, ctx) => {
+      const channel = channels[req.params.channelId]
+      return res(ctx.status(200), ctx.json(channel.messages))
+    },
+  ),
+  rest.post(
+    '*/api/:apiVersion/channels/:channelId/messages',
+    (req, res, ctx) => {
+      const channel = channels[req.params.channelId]
+      const guild = guilds[channel.guild_id]
+      const message = {
+        id: SnowflakeUtil.generate(),
+        channel_id: channel.id,
+        guild_id: channel.guild_id,
+        timestamp: new Date().toISOString(),
+        author: guild.client.user,
+        ...req.body,
+      }
+      channel.messages.push(message)
+      return res(ctx.status(200), ctx.json(message))
+    },
+  ),
+  rest.delete('*/api/:apiVersion/channels/:channelId', (req, res, ctx) => {
+    const channel = channels[req.params.channelId]
+    channel.deleted = true
+    return res(ctx.status(200), ctx.json(channel))
+  }),
+  rest.get('*/api/:apiVersion/gateway/bot', (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        url: '',
+        shards: 9,
+        session_start_limit: {
+          total: 1000,
+          remaining: 999,
+          reset_after: 14400000,
+        },
+      }),
+    )
+  }),
+)
+beforeAll(() => server.listen({onUnhandledRequest: 'error'}))
+afterAll(() => server.close())
+afterEach(() => {
+  server.resetHandlers()
+  channels = {}
+})
 
 async function createPrivateChat(mentionedUsernames = []) {
-  const {client, talkToBotsChannel, guild} = makeFakeClient()
+  const {client, talkToBotsChannel, guild} = await makeFakeClient()
   const sentMessageUser = createUser(client, 'sentMessageUser', guild)
   const message = new Discord.Message(
     client,
@@ -15,40 +84,40 @@ async function createPrivateChat(mentionedUsernames = []) {
     },
     talkToBotsChannel,
   )
+  const mentionedUsers = mentionedUsernames.map(username =>
+    createUser(client, username, guild),
+  )
   Object.assign(message, {
-    mentions: new Discord.MessageMentions(
-      message,
-      mentionedUsernames.map(username => createUser(client, username, guild)),
-      [],
-      false,
-    ),
+    mentions: new Discord.MessageMentions(message, mentionedUsers, [], false),
   })
 
   await privateChat(message)
 
   return {
+    client,
     message,
     guild,
+    mentionedUsers,
   }
+}
+
+function getPrivateChannels(guild) {
+  const categoryPrivateChat = getCategory(guild, {name: 'private chat'})
+  return Array.from(
+    guild.channels.cache
+      .filter(channel => channel.parent?.id === categoryPrivateChat.id)
+      .values(),
+  )
 }
 
 test('should create a private chat', async () => {
   const {message, guild} = await createPrivateChat(['mentionedUser'])
-  expect(message.channel.send).toHaveBeenCalledTimes(1)
-  expect(message.channel.send).toHaveBeenCalledWith(
-    `I've created <#😎-private-mentionedUser-and-others-id> for you folks to talk privately. Cheers!`,
-  )
+  const privateChannels = getPrivateChannels(guild)
 
-  const categoryPrivateChat = getCategory(message.guild, {name: 'private chat'})
-  const privateChannels = Array.from(
-    guild.channels.cache
-      .filter(channel => channel.parentID?.id === categoryPrivateChat.id)
-      .values(),
-  )
   expect(privateChannels).toHaveLength(1)
   const privateChannel = privateChannels[0]
-  expect(privateChannel.send).toHaveBeenCalledTimes(1)
-  expect(privateChannel.send).toHaveBeenCalledWith(
+  expect(privateChannel.lastMessage).toBeDefined()
+  expect(privateChannel.lastMessage.content).toEqual(
     `
 Hello <@!mentionedUser-id> and <@!sentMessageUser-id> 👋
 
@@ -57,7 +126,79 @@ I'm the bot that created this channel for you. The channel will be deleted after
 > Please note that the KCD Discord Server Owners and Admins *can* see this chat. So if you want to be *completely* private, then you'll need to take your communication elsewhere.
 `.trim(),
   )
+
+  expect(message.channel.send).toHaveBeenCalledTimes(1)
+  expect(message.channel.send).toHaveBeenCalledWith(
+    `I've created <#${privateChannel.id}> for you folks to talk privately. Cheers!`,
+  )
 })
+
+test('should delete the private chat after 10 minutes of inactivity', async () => {
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598947200000) // 10:00 UTC+2
+  const {guild} = await createPrivateChat(['mentionedUser'])
+  const privateChannel = getPrivateChannels(guild)[0]
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598947380000) //10:03:00 UTC+2
+  await cleanup(guild)
+  expect(privateChannel.messages.cache.size).toEqual(1)
+
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598947501000) //10:05:01 UTC+2
+  await cleanup(guild)
+  expect(privateChannel.messages.cache.size).toEqual(2)
+  expect(privateChannel.lastMessage.content).toEqual(
+    `This channel will be deleted in 5 minutes for the following reason: deleted for inactivity 🚶‍♀️`,
+  )
+
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598947801000) //10:10:01 UTC+2
+
+  await cleanup(guild)
+  expect(privateChannel.messages.cache.size).toEqual(3)
+  expect(privateChannel.lastMessage.content).toEqual(
+    `
+This channel is getting deleted for the following reason: deleted for inactivity 🚶‍♀️
+  
+  Goodbye 👋
+    `.trim(),
+  )
+})
+
+test('should delete the private chat after 60 minutes', async () => {
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598947200000) // 10:00 UTC+2
+  const {guild, client, mentionedUsers} = await createPrivateChat([
+    'mentionedUser',
+  ])
+  const privateChannel = getPrivateChannels(guild)[0]
+
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598950501000) //10:55:01 UTC+2
+  const fakeUserMessage = new Discord.Message(
+    client,
+    {
+      id: SnowflakeUtil.generate(Date.now()),
+      content: 'Some content',
+      author: mentionedUsers[0].user,
+    },
+    privateChannel,
+  )
+  privateChannel.messages.cache.set(fakeUserMessage.id, fakeUserMessage)
+  channels[privateChannel.id].messages.push(fakeUserMessage)
+  await cleanup(guild)
+  expect(privateChannel.messages.cache.size).toEqual(3)
+  expect(privateChannel.lastMessage.content).toEqual(
+    `This channel will be deleted in 5 minutes for the following reason: deleted for end of life 👻`,
+  )
+
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598950801000) //11:00:01 UTC+2
+
+  await cleanup(guild)
+  expect(privateChannel.messages.cache.size).toEqual(4)
+  expect(privateChannel.lastMessage.content).toEqual(
+    `
+This channel is getting deleted for the following reason: deleted for end of life 👻
+  
+  Goodbye 👋
+    `.trim(),
+  )
+})
+
 test('should not create a chat without mentioned member', async () => {
   const {message} = await createPrivateChat()
   expect(message.channel.send).toHaveBeenCalledTimes(1)

--- a/src/commands/command-fns/__tests__/private-chat.js
+++ b/src/commands/command-fns/__tests__/private-chat.js
@@ -158,3 +158,14 @@ test('should not create a chat without mentioned member', async () => {
     'You should mention at least one other member.',
   )
 })
+
+test('should give an error trying to create a chat for the same members', async () => {
+  const {message, guild} = await createPrivateChat(['mentionedUser'])
+  const privateChannel = getPrivateChannels(guild)[0]
+  await privateChat(message)
+
+  expect(message.channel.send).toHaveBeenCalledTimes(2)
+  expect(message.channel.send).toHaveBeenCalledWith(
+    `There is already a chat for the same members <#${privateChannel.id}>`,
+  )
+})

--- a/src/commands/command-fns/__tests__/private-chat.js
+++ b/src/commands/command-fns/__tests__/private-chat.js
@@ -1,0 +1,18 @@
+const Discord = require('discord.js')
+const {makeFakeClient} = require('test-utils')
+const privateChat = require('../private-chat')
+
+test('should not create a chat without mentioned member', async () => {
+  const {client, talkToBotsChannel} = makeFakeClient()
+  const message = new Discord.Message(
+    client,
+    {id: 'private_chat_test', content: '?private-chat @Username1'},
+    talkToBotsChannel,
+  )
+  await privateChat(message)
+
+  expect(message.channel.send).toHaveBeenCalledTimes(1)
+  expect(message.channel.send).toHaveBeenCalledWith(
+    'You should mention at least one other member.',
+  )
+})

--- a/src/commands/command-fns/__tests__/private-chat.js
+++ b/src/commands/command-fns/__tests__/private-chat.js
@@ -31,11 +31,12 @@ async function createPrivateChat(mentionedUsernames = []) {
   })
 
   await privateChat(message)
-
+  const botsMessages = Array.from(talkToBotsChannel.messages.cache.values())
   return {
     client,
     message,
     guild,
+    botsMessages,
     channelMembers: [sentMessageUser, ...mentionedUsers],
     addUserMessage,
   }
@@ -51,7 +52,7 @@ function getPrivateChannels(guild) {
 }
 
 test('should create a private chat for two users', async () => {
-  const {message, guild, channelMembers} = await createPrivateChat([
+  const {guild, channelMembers, botsMessages} = await createPrivateChat([
     'mentionedUser',
   ])
   const privateChannels = getPrivateChannels(guild)
@@ -72,8 +73,8 @@ I'm the bot that created this channel for you. The channel will be deleted after
 `.trim(),
   )
 
-  expect(message.channel.send).toHaveBeenCalledTimes(1)
-  expect(message.channel.send).toHaveBeenCalledWith(
+  expect(botsMessages).toHaveLength(1)
+  expect(botsMessages[0].content).toEqual(
     `I've created <#${privateChannel.id}> for you folks to talk privately. Cheers!`,
   )
 })
@@ -164,9 +165,9 @@ This channel is getting deleted for the following reason: deleted for end of lif
 })
 
 test('should not create a chat without mentioned member', async () => {
-  const {message} = await createPrivateChat()
-  expect(message.channel.send).toHaveBeenCalledTimes(1)
-  expect(message.channel.send).toHaveBeenCalledWith(
+  const {botsMessages} = await createPrivateChat()
+  expect(botsMessages).toHaveLength(1)
+  expect(botsMessages[0].content).toEqual(
     'You should mention at least one other member.',
   )
 })
@@ -176,8 +177,9 @@ test('should give an error trying to create a chat for the same members', async 
   const privateChannel = getPrivateChannels(guild)[0]
   await privateChat(message)
 
-  expect(message.channel.send).toHaveBeenCalledTimes(2)
-  expect(message.channel.send).toHaveBeenCalledWith(
+  const botsMessages = Array.from(message.channel.messages.cache.values())
+  expect(botsMessages).toHaveLength(2)
+  expect(botsMessages[1].content).toEqual(
     `There is already a chat for the same members <#${privateChannel.id}>`,
   )
 })
@@ -205,8 +207,9 @@ test('should not create a private-chat with yourself', async () => {
 
   await privateChat(message)
 
-  expect(message.channel.send).toHaveBeenCalledTimes(1)
-  expect(message.channel.send).toHaveBeenCalledWith(
+  const botsMessages = Array.from(talkToBotsChannel.messages.cache.values())
+  expect(botsMessages).toHaveLength(1)
+  expect(botsMessages[0].content).toEqual(
     `You should mention at least one other member.`,
   )
 })

--- a/src/commands/command-fns/__tests__/private-chat.js
+++ b/src/commands/command-fns/__tests__/private-chat.js
@@ -102,14 +102,9 @@ This channel is getting deleted for the following reason: deleted for inactivity
     `.trim(),
   )
 
-  await waitUntil(
-    () => {
-      expect(privateChannel.deleted).toBeTruthy()
-    },
-    {
-      timeout: 3000,
-    },
-  )
+  await waitUntil(() => {
+    expect(privateChannel.deleted).toBeTruthy()
+  })
 })
 
 test('should delete the private chat after 60 minutes', async () => {
@@ -141,14 +136,9 @@ This channel is getting deleted for the following reason: deleted for end of lif
     `.trim(),
   )
 
-  await waitUntil(
-    () => {
-      expect(privateChannel.deleted).toBeTruthy()
-    },
-    {
-      timeout: 3000,
-    },
-  )
+  await waitUntil(() => {
+    expect(privateChannel.deleted).toBeTruthy()
+  })
 })
 
 test('should not create a chat without mentioned member', async () => {

--- a/src/commands/command-fns/kif.js
+++ b/src/commands/command-fns/kif.js
@@ -10,7 +10,6 @@ const {
   getMember,
   rollbar,
   sendBotMessageReply,
-  getUsername,
 } = require('../utils')
 
 const kifCache = {
@@ -75,10 +74,10 @@ async function getCloseMatches(search) {
 function getKifReply(message, kif) {
   const mentionedMembersNicknames = Array.from(
     message.mentions.members.values(),
-  ).map(m => getUsername(m))
-  const from = `From: ${getUsername(
-    getMember(message.guild, message.author.id),
-  )}`
+  ).map(m => m.displayName)
+  const from = `From: ${
+    getMember(message.guild, message.author.id).displayName
+  }`
   const to = mentionedMembersNicknames.length
     ? `To: ${listify(mentionedMembersNicknames, {stringify: i => i})}`
     : ''

--- a/src/commands/command-fns/kif.js
+++ b/src/commands/command-fns/kif.js
@@ -10,6 +10,7 @@ const {
   getMember,
   rollbar,
   sendBotMessageReply,
+  getUsername,
 } = require('../utils')
 
 const kifCache = {
@@ -74,8 +75,10 @@ async function getCloseMatches(search) {
 function getKifReply(message, kif) {
   const mentionedMembersNicknames = Array.from(
     message.mentions.members.values(),
-  ).map(m => m.nickname ?? m.user.username)
-  const from = `From: ${getMember(message.guild, message.author.id).nickname}`
+  ).map(m => getUsername(m))
+  const from = `From: ${getUsername(
+    getMember(message.guild, message.author.id),
+  )}`
   const to = mentionedMembersNicknames.length
     ? `To: ${listify(mentionedMembersNicknames, {stringify: i => i})}`
     : ''

--- a/src/commands/command-fns/private-chat.js
+++ b/src/commands/command-fns/private-chat.js
@@ -4,7 +4,6 @@ const {
   listify,
   sendBotMessageReply,
   getCategory,
-  getUsername,
   getMember,
 } = require('../utils')
 
@@ -14,10 +13,10 @@ async function privateChat(message) {
   )
   const mentionedMembersNicknames = Array.from(
     message.mentions.members.values(),
-  ).map(user => getUsername(user))
+  ).map(user => user.displayName)
   mentionedMembers.push(message.author)
   mentionedMembersNicknames.push(
-    getUsername(getMember(message.guild, message.author.id)),
+    getMember(message.guild, message.author.id).displayName,
   )
   if (mentionedMembers.length < 2) {
     return message.channel.send(`You should mention at least one other member.`)

--- a/src/commands/command-fns/private-chat.js
+++ b/src/commands/command-fns/private-chat.js
@@ -4,6 +4,8 @@ const {
   listify,
   sendBotMessageReply,
   getCategory,
+  getUsername,
+  getMember,
 } = require('../utils')
 
 async function privateChat(message) {
@@ -12,11 +14,11 @@ async function privateChat(message) {
   )
   const mentionedMembersNicknames = Array.from(
     message.mentions.members.values(),
-  ).map(user => {
-    return user.nickname ?? user.user.username
-  })
+  ).map(user => getUsername(user))
   mentionedMembers.push(message.author)
-  mentionedMembersNicknames.push(message.author.username)
+  mentionedMembersNicknames.push(
+    getUsername(getMember(message.guild, message.author.id)),
+  )
   if (mentionedMembers.length < 2) {
     return message.channel.send(`You should mention at least one other member.`)
   }

--- a/src/commands/command-fns/private-chat.js
+++ b/src/commands/command-fns/private-chat.js
@@ -1,5 +1,10 @@
 const Discord = require('discord.js')
-const {privateChannelPrefix, listify, sendBotMessageReply} = require('../utils')
+const {
+  privateChannelPrefix,
+  listify,
+  sendBotMessageReply,
+  getCategory,
+} = require('../utils')
 
 async function privateChat(message) {
   const mentionedMembers = [
@@ -42,10 +47,7 @@ async function privateChat(message) {
     ({name}) => name === '@everyone',
   )
 
-  const categoryPrivateChat = message.guild.channels.cache.find(
-    ({name, type}) =>
-      type === 'category' && name.toLowerCase().includes('private chat'),
-  )
+  const categoryPrivateChat = getCategory(message.guild, {name: 'private chat'})
 
   const allActivePrivateChannels = message.guild.channels.cache.filter(
     channel =>
@@ -91,7 +93,7 @@ async function privateChat(message) {
     `
 Hello ${listify(mentionedMembers, {stringify: member => member})} 👋
 
-I'm the bot that created this channel for you. The channel will be deleted after 1 hour or after 10 minutes for inactivity. Enjoy 🗣 
+I'm the bot that created this channel for you. The channel will be deleted after 1 hour or after 10 minutes for inactivity. Enjoy 🗣
 
 > Please note that the KCD Discord Server Owners and Admins *can* see this chat. So if you want to be *completely* private, then you'll need to take your communication elsewhere.
     `.trim(),

--- a/src/commands/command-fns/private-chat.js
+++ b/src/commands/command-fns/private-chat.js
@@ -12,8 +12,11 @@ async function privateChat(message) {
   )
   const mentionedMembersNicknames = Array.from(
     message.mentions.members.values(),
-  ).map(user => user.nickname ?? user.user.username)
-  mentionedMembers.push(message.member)
+  ).map(user => {
+    return user.nickname ?? user.user.username
+  })
+  mentionedMembers.push(message.author)
+  mentionedMembersNicknames.push(message.author.username)
   if (mentionedMembers.length < 2) {
     return message.channel.send(`You should mention at least one other member.`)
   }

--- a/src/commands/command-fns/private-chat.js
+++ b/src/commands/command-fns/private-chat.js
@@ -7,13 +7,13 @@ const {
 } = require('../utils')
 
 async function privateChat(message) {
-  const mentionedMembers = [
-    ...Array.from(message.mentions.members.values()),
-    message.member,
-  ]
+  const mentionedMembers = Array.from(message.mentions.members.values()).filter(
+    user => user.user.id !== message.member.id,
+  )
   const mentionedMembersNicknames = Array.from(
     message.mentions.members.values(),
-  ).map(m => m.nickname ?? m.user.username)
+  ).map(user => user.nickname ?? user.user.username)
+  mentionedMembers.push(message.member)
   if (mentionedMembers.length < 2) {
     return message.channel.send(`You should mention at least one other member.`)
   }

--- a/src/commands/command-fns/thanks.js
+++ b/src/commands/command-fns/thanks.js
@@ -8,7 +8,6 @@ const {
   getMember,
   getChannel,
   getMessageLink,
-  getUsername,
 } = require('../utils')
 
 async function getThanksHistory() {
@@ -57,7 +56,7 @@ async function sayThankYou(args, message, thanksHistory) {
     )
   }
   const thankedMembersListString = listify(thankedMembers, {
-    stringify: m => `@${getUsername(m)}`,
+    stringify: m => `@${m.displayName}`,
   })
   const example = `For example: \`?thanks ${thankedMembersListString} for being so nice and answering my questions\``
   if (!args.includes(' for ')) {

--- a/src/commands/command-fns/thanks.js
+++ b/src/commands/command-fns/thanks.js
@@ -8,6 +8,7 @@ const {
   getMember,
   getChannel,
   getMessageLink,
+  getUsername,
 } = require('../utils')
 
 async function getThanksHistory() {
@@ -56,7 +57,7 @@ async function sayThankYou(args, message, thanksHistory) {
     )
   }
   const thankedMembersListString = listify(thankedMembers, {
-    stringify: m => `@${m.nickname ?? m.user.username}`,
+    stringify: m => `@${getUsername(m)}`,
   })
   const example = `For example: \`?thanks ${thankedMembersListString} for being so nice and answering my questions\``
   if (!args.includes(' for ')) {

--- a/src/private-chat/cleanup.js
+++ b/src/private-chat/cleanup.js
@@ -1,10 +1,8 @@
-const {getSend, sleep} = require('../utils')
+/* eslint-disable no-await-in-loop */
+const {getSend, sleep, getCategory} = require('../utils')
 
 async function cleanup(guild) {
-  const categoryPrivateChat = guild.channels.cache.find(
-    ({name, type}) =>
-      type === 'category' && name.toLowerCase().includes('private chat'),
-  )
+  const categoryPrivateChat = getCategory(guild, {name: 'private chat'})
 
   const warningStep = 1000 * 60 * 5
   const maxExistingTime = 1000 * 60 * 60
@@ -13,20 +11,33 @@ async function cleanup(guild) {
   const eolReason = 'deleted for end of life 👻'
   const inactivityReason = 'deleted for inactivity 🚶‍♀️'
 
-  const allActivePrivateChannels = guild.channels.cache.filter(
-    channel =>
-      channel.type === 'text' &&
-      channel.parentID === categoryPrivateChat.id &&
-      channel.name.includes('-private-') &&
-      !channel.deleted,
+  const allActivePrivateChannels = Array.from(
+    guild.channels.cache
+      .filter(
+        channel =>
+          channel.type === 'text' &&
+          channel.parentID === categoryPrivateChat.id &&
+          channel.name.includes('-private-') &&
+          !channel.deleted,
+      )
+      .values(),
   )
 
-  allActivePrivateChannels.forEach(async channel => {
+  for (const channel of allActivePrivateChannels) {
     const channelCreateDate = channel.createdAt
-    const lastMessageDate = channel.lastMessage?.createdAt ?? channelCreateDate
-    const timeSinceChannelCreation = new Date() - channelCreateDate
-    const timeSinceLastMessage = new Date() - lastMessageDate
-    const messages = Array.from((await channel.messages.fetch()).values())
+
+    const timeSinceChannelCreation = Date.now() - channelCreateDate
+
+    const allMessages = Array.from((await channel.messages.fetch()).values())
+    const messages = allMessages
+      .filter(message => message.author?.bot === false)
+      .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
+    let timeSinceLastMessage = timeSinceChannelCreation
+
+    if (messages.length > 0) {
+      timeSinceLastMessage = Date.now() - messages[0].createdTimestamp
+    }
+
     const hasInactiveWarned = messages.some(message => {
       return (
         message.content.includes('5 minutes') &&
@@ -63,8 +74,9 @@ async function cleanup(guild) {
           `.trim(),
         )
         // Give just a while for the users to understand that the channel will be deleted soon
-        await sleep(10000)
-        await channel.delete(reason)
+        sleep(10000).then(() => {
+          channel.delete(reason)
+        })
       }
       // After two minute from deletion we try to delate the channel again
       // Maybe the server was stopped and the previous sleep was not finished
@@ -74,11 +86,7 @@ async function cleanup(guild) {
       ) {
         await channel.delete(reason)
       }
-
-      return
-    }
-
-    if (
+    } else if (
       (timeSinceChannelCreation > maxExistingTime - warningStep ||
         timeSinceLastMessage > maxInactiveTime - warningStep) &&
       !hasInactiveWarned &&
@@ -95,16 +103,16 @@ async function cleanup(guild) {
         !hasInactiveWarned
       ) {
         reason = inactivityReason
-      } else {
-        return
       }
-      await send(
-        `
+      if (reason) {
+        await send(
+          `
 This channel will be deleted in 5 minutes for the following reason: ${reason}
         `.trim(),
-      )
+        )
+      }
     }
-  })
+  }
 }
 
 module.exports = {cleanup}

--- a/src/private-chat/cleanup.js
+++ b/src/private-chat/cleanup.js
@@ -31,7 +31,7 @@ async function cleanup(guild) {
     const allMessages = Array.from((await channel.messages.fetch()).values())
     const messages = allMessages
       .filter(message => message.author?.bot === false)
-      .sort((a, b) => a.createdTimestamp - b.createdTimestamp)
+      .sort((a, b) => b.createdTimestamp - a.createdTimestamp)
     let timeSinceLastMessage = timeSinceChannelCreation
 
     if (messages.length > 0) {

--- a/src/private-chat/cleanup.js
+++ b/src/private-chat/cleanup.js
@@ -29,8 +29,9 @@ async function cleanup(guild) {
     const timeSinceChannelCreation = Date.now() - channelCreateDate
 
     const allMessages = Array.from((await channel.messages.fetch()).values())
+    const botMessages = allMessages.filter(message => message.author?.bot)
     const messages = allMessages
-      .filter(message => message.author?.bot === false)
+      .filter(message => !message.author?.bot)
       .sort((a, b) => b.createdTimestamp - a.createdTimestamp)
     let timeSinceLastMessage = timeSinceChannelCreation
 
@@ -38,18 +39,18 @@ async function cleanup(guild) {
       timeSinceLastMessage = Date.now() - messages[0].createdTimestamp
     }
 
-    const hasInactiveWarned = messages.some(message => {
+    const hasInactiveWarned = botMessages.some(message => {
       return (
         message.content.includes('5 minutes') &&
         message.content.includes(inactivityReason)
       )
     })
-    const hasEOLWarned = messages.some(
+    const hasEOLWarned = botMessages.some(
       message =>
         message.content.includes('5 minutes') &&
         message.content.includes(eolReason),
     )
-    const isGettingDeleted = messages.some(message =>
+    const isGettingDeleted = botMessages.some(message =>
       message.content.includes(
         'This channel is getting deleted for the following reason',
       ),

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,6 +75,15 @@ function getCategory(guild, {name}) {
   )
 }
 
+/**
+ * Get the username of the user from the given GuildMember
+ * @param member
+ * @returns {string|*|string|T|null}
+ */
+function getUsername(member) {
+  return member.nickname ?? member.user.username
+}
+
 const prodRegex = /^\?(?<command>\S+?)($| )(?<args>(.|\n)*)/
 const devRegex = /^~(?<command>\S+?)($| )(?<args>(.|\n)*)/
 const commandPrefix =
@@ -179,4 +188,5 @@ module.exports = {
   getSelfDestructTime,
   welcomeChannelPrefix,
   privateChannelPrefix,
+  getUsername,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -75,15 +75,6 @@ function getCategory(guild, {name}) {
   )
 }
 
-/**
- * Get the username of the user from the given GuildMember
- * @param member
- * @returns {string|*|string|T|null}
- */
-function getUsername(member) {
-  return member.nickname ?? member.user.username
-}
-
 const prodRegex = /^\?(?<command>\S+?)($| )(?<args>(.|\n)*)/
 const devRegex = /^~(?<command>\S+?)($| )(?<args>(.|\n)*)/
 const commandPrefix =
@@ -188,5 +179,4 @@ module.exports = {
   getSelfDestructTime,
   welcomeChannelPrefix,
   privateChannelPrefix,
-  getUsername,
 }

--- a/src/utils.js
+++ b/src/utils.js
@@ -63,6 +63,18 @@ function getRole(guild, {name}) {
   )
 }
 
+/**
+ * The name will be lowercased and the first category with a lowercased name that
+ * equals it will be returned.
+ * @param {*} guild the guild to find the role in
+ * @param {{name: string}} searchOptions
+ */
+function getCategory(guild, {name}) {
+  return guild.channels.cache.find(
+    c => c.type === 'category' && c.name.toLowerCase() === name.toLowerCase(),
+  )
+}
+
 const prodRegex = /^\?(?<command>\S+?)($| )(?<args>(.|\n)*)/
 const devRegex = /^~(?<command>\S+?)($| )(?<args>(.|\n)*)/
 const commandPrefix =
@@ -153,6 +165,7 @@ module.exports = {
   getMemberIdFromChannel,
   getBotMessages,
   getChannel,
+  getCategory,
   getRole,
   commandPrefix,
   commandRegex,

--- a/tests/DiscordManager.js
+++ b/tests/DiscordManager.js
@@ -1,0 +1,6 @@
+class DiscordManager {
+  static channels = {}
+  static guilds = {}
+}
+
+module.exports = DiscordManager

--- a/tests/DiscordManager.js
+++ b/tests/DiscordManager.js
@@ -1,3 +1,7 @@
+/**
+ * this class is used by the API to get channel and guild by their ids.
+ * The only thing to remember is that if a new message
+ **/
 class DiscordManager {
   static channels = {}
   static guilds = {}

--- a/tests/DiscordManager.js
+++ b/tests/DiscordManager.js
@@ -1,17 +1,17 @@
 /**
  * this class is used by the API to get channel and guild by their ids.
- * The only thing to remember is that if a new message
+ * This is useful to clean up all things after each test and
+ * to enable API to access guilds and channels because we don't have a DB
  **/
-class DiscordManager {
-  static channels = {}
-  static guilds = {}
-  static clients = []
-
-  static cleanup() {
-    this.channels = {}
-    this.guilds = {}
-    this.clients.forEach(client => client.destroy())
-  }
+const DiscordManager = {
+  channels: {},
+  guilds: {},
+  clients: [],
+  cleanup: () => {
+    DiscordManager.channels = {}
+    DiscordManager.guilds = {}
+    DiscordManager.clients.forEach(client => client.destroy())
+  },
 }
 
 module.exports = DiscordManager

--- a/tests/DiscordManager.js
+++ b/tests/DiscordManager.js
@@ -5,6 +5,13 @@
 class DiscordManager {
   static channels = {}
   static guilds = {}
+  static clients = []
+
+  static cleanup() {
+    this.channels = {}
+    this.guilds = {}
+    this.clients.forEach(client => client.destroy())
+  }
 }
 
 module.exports = DiscordManager

--- a/tests/handlers/blog.js
+++ b/tests/handlers/blog.js
@@ -1,0 +1,10 @@
+const {rest} = require('msw')
+const posts = require('../data/kcd-blog.json')
+
+const handlers = [
+  rest.get('https://kentcdodds.com/blog.json', (req, res, ctx) => {
+    return res(ctx.json(posts))
+  }),
+]
+
+module.exports = handlers

--- a/tests/handlers/discord.js
+++ b/tests/handlers/discord.js
@@ -1,0 +1,67 @@
+const {rest} = require('msw')
+const {SnowflakeUtil} = require('discord.js')
+const {DiscordManager} = require('test-utils')
+
+const handlers = [
+  rest.post('*/api/:apiVersion/guilds/:guild/channels', (req, res, ctx) => {
+    const createdChannel = {
+      id: SnowflakeUtil.generate(),
+      guild_id: req.params.guild,
+      ...req.body,
+    }
+    DiscordManager.channels[createdChannel.id] = {
+      ...createdChannel,
+      messages: [],
+    }
+
+    return res(ctx.status(200), ctx.json(createdChannel))
+  }),
+  rest.get(
+    '*/api/:apiVersion/channels/:channelId/messages',
+    (req, res, ctx) => {
+      const channel = DiscordManager.channels[req.params.channelId]
+      return res(ctx.status(200), ctx.json(channel.messages))
+    },
+  ),
+  rest.post(
+    '*/api/:apiVersion/channels/:channelId/messages',
+    (req, res, ctx) => {
+      const channel = DiscordManager.channels[req.params.channelId]
+      const guild = DiscordManager.guilds[channel.guild_id]
+      const message = {
+        id: SnowflakeUtil.generate(),
+        channel_id: channel.id,
+        guild_id: channel.guild_id,
+        timestamp: new Date().toISOString(),
+        author: guild.client.user,
+        ...req.body,
+      }
+      channel.messages.push(message)
+      return res(ctx.status(200), ctx.json(message))
+    },
+  ),
+  rest.delete('*/api/:apiVersion/channels/:channelId', (req, res, ctx) => {
+    const channel = DiscordManager.channels[req.params.channelId]
+    channel.deleted = true
+    DiscordManager.guilds[channel.guild_id].client.actions.ChannelDelete.handle(
+      channel,
+    )
+    return res(ctx.status(200), ctx.json(channel))
+  }),
+  rest.get('*/api/:apiVersion/gateway/bot', (req, res, ctx) => {
+    return res(
+      ctx.status(200),
+      ctx.json({
+        url: '',
+        shards: 9,
+        session_start_limit: {
+          total: 1000,
+          remaining: 999,
+          reset_after: 14400000,
+        },
+      }),
+    )
+  }),
+]
+
+module.exports = handlers

--- a/tests/handlers/discord.js
+++ b/tests/handlers/discord.js
@@ -24,8 +24,80 @@ const handlers = [
       ).find(channel => channel.id === cachedChannel.id)
       return res(
         ctx.status(200),
-        ctx.json(Array.from(discordChannel.messages.cache.values())),
+        ctx.json(Array.from(discordChannel.messages.cache.values()).reverse()),
       )
+    },
+  ),
+  rest.delete(
+    '*/api/:apiVersion/channels/:channelId/messages/:messageId',
+    (req, res, ctx) => {
+      const channel = DiscordManager.channels[req.params.channelId]
+      const deletedMessage = {
+        id: req.params.messageId,
+        channel_id: req.params.channelId,
+      }
+      DiscordManager.guilds[
+        channel.guild_id
+      ].client.actions.MessageDelete.handle(deletedMessage)
+      return res(ctx.status(200), ctx.json(deletedMessage))
+    },
+  ),
+  rest.patch(
+    '*/api/:apiVersion/channels/:channelId/messages/:messageId',
+    (req, res, ctx) => {
+      const channel = DiscordManager.channels[req.params.channelId]
+      const editedMessage = {
+        ...req.body,
+        id: req.params.messageId,
+        channel_id: req.params.channelId,
+      }
+      DiscordManager.guilds[
+        channel.guild_id
+      ].client.actions.MessageUpdate.handle(editedMessage)
+
+      return res(ctx.status(200), ctx.json(editedMessage))
+    },
+  ),
+  rest.put(
+    `*/api/:apiVersion/channels/:channelId/messages/:messageId/reactions/*/@me`,
+    (req, res, ctx) => {
+      return res(ctx.status(200), ctx.json(req.body))
+    },
+  ),
+  rest.delete(
+    '*/api/:apiVersion/guilds/:guildId/members/:memberId/roles/:roleId',
+    (req, res, ctx) => {
+      const updateUser = {
+        id: req.params.memberId,
+      }
+      const guild = DiscordManager.guilds[req.params.guildId]
+
+      const user = Array.from(guild.members.cache.values()).find(
+        guildMember => guildMember.user.id === req.params.memberId,
+      )
+      const removedRole = Array.from(guild.roles.cache.values()).find(
+        role => role.id === req.params.roleId,
+      )
+      user._roles = user._roles.filter(roleId => roleId !== removedRole.id)
+      return res(ctx.status(200), ctx.json(updateUser))
+    },
+  ),
+  rest.put(
+    '*/api/:apiVersion/guilds/:guildId/members/:memberId/roles/:roleId',
+    (req, res, ctx) => {
+      const updateUser = {
+        id: req.params.memberId,
+      }
+      const guild = DiscordManager.guilds[req.params.guildId]
+
+      const user = Array.from(guild.members.cache.values()).find(
+        guildMember => guildMember.user.id === req.params.memberId,
+      )
+      const assigneRole = Array.from(guild.roles.cache.values()).find(
+        role => role.id === req.params.roleId,
+      )
+      user._roles.push(assigneRole.id)
+      return res(ctx.status(200), ctx.json(updateUser))
     },
   ),
   rest.patch(
@@ -57,6 +129,13 @@ const handlers = [
       channel,
     )
     return res(ctx.status(200), ctx.json(channel))
+  }),
+  rest.post('*/api/:apiVersion/guilds/:guildId/emojis', (req, res, ctx) => {
+    const emoji = {
+      id: SnowflakeUtil.generate(),
+      ...req.body,
+    }
+    return res(ctx.status(200), ctx.json(emoji))
   }),
   rest.get('*/api/:apiVersion/gateway/bot', (req, res, ctx) => {
     return res(

--- a/tests/handlers/discord.js
+++ b/tests/handlers/discord.js
@@ -11,7 +11,6 @@ const handlers = [
     }
     DiscordManager.channels[createdChannel.id] = {
       ...createdChannel,
-      messages: [],
     }
 
     return res(ctx.status(200), ctx.json(createdChannel))
@@ -19,8 +18,14 @@ const handlers = [
   rest.get(
     '*/api/:apiVersion/channels/:channelId/messages',
     (req, res, ctx) => {
-      const channel = DiscordManager.channels[req.params.channelId]
-      return res(ctx.status(200), ctx.json(channel.messages))
+      const cachedChannel = DiscordManager.channels[req.params.channelId]
+      const discordChannel = Array.from(
+        DiscordManager.guilds[cachedChannel.guild_id].channels.cache.values(),
+      ).find(channel => channel.id === cachedChannel.id)
+      return res(
+        ctx.status(200),
+        ctx.json(Array.from(discordChannel.messages.cache.values())),
+      )
     },
   ),
   rest.post(
@@ -36,7 +41,6 @@ const handlers = [
         author: guild.client.user,
         ...req.body,
       }
-      channel.messages.push(message)
       return res(ctx.status(200), ctx.json(message))
     },
   ),

--- a/tests/handlers/discord.js
+++ b/tests/handlers/discord.js
@@ -28,6 +28,12 @@ const handlers = [
       )
     },
   ),
+  rest.patch(
+    '*/api/:apiVersion/guilds/:guildId/members/:memberId',
+    (req, res, ctx) => {
+      return res(ctx.status(200), ctx.json({}))
+    },
+  ),
   rest.post(
     '*/api/:apiVersion/channels/:channelId/messages',
     (req, res, ctx) => {

--- a/tests/handlers/index.js
+++ b/tests/handlers/index.js
@@ -1,5 +1,11 @@
 const kifHandlers = require('./kif')
 const blogHandlers = require('./blog')
 const discordHandlers = require('./discord')
+const onBoardHandlers = require('./onBoarding')
 
-module.exports = [...kifHandlers, ...blogHandlers, ...discordHandlers]
+module.exports = [
+  ...kifHandlers,
+  ...blogHandlers,
+  ...discordHandlers,
+  ...onBoardHandlers,
+]

--- a/tests/handlers/index.js
+++ b/tests/handlers/index.js
@@ -1,0 +1,5 @@
+const kifHandlers = require('./kif')
+const blogHandlers = require('./blog')
+const discordHandlers = require('./discord')
+
+module.exports = [...kifHandlers, ...blogHandlers, ...discordHandlers]

--- a/tests/handlers/kif.js
+++ b/tests/handlers/kif.js
@@ -1,6 +1,5 @@
 const {rest} = require('msw')
-const kif = require('./data/kif.json')
-const posts = require('./data/kcd-blog.json')
+const kif = require('../data/kif.json')
 
 const handlers = [
   rest.get(
@@ -14,9 +13,6 @@ const handlers = [
       )
     },
   ),
-  rest.get('https://kentcdodds.com/blog.json', (req, res, ctx) => {
-    return res(ctx.json(posts))
-  }),
 ]
 
 module.exports = handlers

--- a/tests/handlers/onBoarding.js
+++ b/tests/handlers/onBoarding.js
@@ -1,0 +1,75 @@
+const {rest} = require('msw')
+
+const handlers = [
+  rest.get('https://api.convertkit.com/v3/subscribers', (req, res, ctx) => {
+    return res(
+      ctx.json({
+        total_subscribers: 0,
+        page: 1,
+        total_pages: 1,
+        subscribers: [],
+      }),
+    )
+  }),
+  rest.post(
+    'https://api.convertkit.com/v3/forms/:formId/subscribe',
+    (req, res, ctx) => {
+      const {formId} = req.params
+      const {first_name, email, fields} = req.body
+      return res(
+        ctx.json({
+          subscription: {
+            id: 1234567890,
+            state: 'active',
+            created_at: new Date().toJSON(),
+            source: 'API::V3::SubscriptionsController (external)',
+            referrer: null,
+            subscribable_id: formId,
+            subscribable_type: 'form',
+            subscriber: {
+              id: 987654321,
+              first_name,
+              email_address: email,
+              state: 'inactive',
+              created_at: new Date().toJSON(),
+              fields,
+            },
+          },
+        }),
+      )
+    },
+  ),
+  rest.post(
+    'https://api.convertkit.com/v3/tags/:tagId/subscribe',
+    (req, res, ctx) => {
+      const {tagId} = req.params
+      const {first_name, email, fields} = req.body
+      return res(
+        ctx.json({
+          subscription: {
+            id: 1234567890,
+            state: 'active',
+            created_at: new Date().toJSON(),
+            source: 'API::V3::SubscriptionsController (external)',
+            referrer: null,
+            subscribable_id: tagId,
+            subscribable_type: 'tag',
+            subscriber: {
+              id: 987654321,
+              first_name,
+              email_address: email,
+              state: 'inactive',
+              created_at: new Date().toJSON(),
+              fields,
+            },
+          },
+        }),
+      )
+    },
+  ),
+  rest.get('https://www.gravatar.com/avatar/:hash', (req, res, ctx) => {
+    return res(ctx.status(200))
+  }),
+]
+
+module.exports = handlers

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -9,6 +9,5 @@ beforeAll(() => server.listen({onUnhandledRequest: 'error'}))
 afterAll(() => server.close())
 afterEach(() => {
   server.resetHandlers()
-  DiscordManager.guilds = {}
-  DiscordManager.channels = {}
+  DiscordManager.cleanup()
 })

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -1,3 +1,4 @@
+const {DiscordManager} = require('test-utils')
 const {server} = require('./server')
 
 process.env.CONVERT_KIT_API_KEY = 'FAKE_CONVERT_KIT_API_KEY'
@@ -6,4 +7,8 @@ process.env.DISCORD_BOT_TOKEN = 'FAKE_BOT_TOKEN'
 
 beforeAll(() => server.listen({onUnhandledRequest: 'error'}))
 afterAll(() => server.close())
-afterEach(() => server.resetHandlers())
+afterEach(() => {
+  server.resetHandlers()
+  DiscordManager.guilds = {}
+  DiscordManager.channels = {}
+})

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -2,6 +2,7 @@ const {server} = require('./server')
 
 process.env.CONVERT_KIT_API_KEY = 'FAKE_CONVERT_KIT_API_KEY'
 process.env.CONVERT_KIT_API_SECRET = 'FAKE_CONVERT_KIT_API_SECRET'
+process.env.DISCORD_BOT_TOKEN = 'FAKE_BOT_TOKEN'
 
 beforeAll(() => server.listen({onUnhandledRequest: 'error'}))
 afterAll(() => server.close())

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -88,7 +88,6 @@ async function makeFakeClient() {
       channel,
     )
     channel.messages.cache.set(userMessage.id, userMessage)
-    DiscordManager.channels[channel.id].messages.push(userMessage)
   }
 
   return {

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -71,12 +71,30 @@ function makeFakeClient() {
   jest
     .spyOn(guild.channels, 'create')
     .mockImplementation((name, channelOptions) => {
+      const {
+        topic,
+        nsfw,
+        bitrate,
+        userLimit,
+        parent,
+        permissionOverwrites,
+        position,
+        rateLimitPerUser,
+      } = channelOptions
       const newChannel = new Discord.TextChannel(guild, {
-        type: Discord.Constants.ChannelTypes.TEXT,
         id: `${name}-id`,
         name,
-        ...channelOptions,
+        type: Discord.Constants.ChannelTypes.TEXT,
+        topic,
+        nsfw,
+        bitrate,
+        user_limit: userLimit,
+        parent_id: parent,
+        position,
+        permission_overwrites: permissionOverwrites,
+        rate_limit_per_user: rateLimitPerUser,
       })
+      guild.channels.cache.set(newChannel.id, newChannel)
       jest
         .spyOn(newChannel, 'send')
         .mockImplementation(content =>

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -1,7 +1,6 @@
 const Discord = require('discord.js')
 const {SnowflakeUtil} = require('discord.js')
-
-const guilds = {}
+const DiscordManager = require('./DiscordManager')
 
 async function makeFakeClient() {
   const client = new Discord.Client()
@@ -20,7 +19,8 @@ async function makeFakeClient() {
     id: SnowflakeUtil.generate(),
     name: 'KCD',
   })
-  guilds[guild.id] = guild
+  guild.messages = []
+  DiscordManager.guilds[guild.id] = guild
   const everyoneRole = new Discord.Role(
     client,
     // the everyone role has the same id as the guild.
@@ -61,9 +61,7 @@ async function makeFakeClient() {
     type: 'CATEGORY',
   })
   guild.channels.cache.set(privateChatCategory.id, privateChatCategory)
-  afterEach(() => {
-    delete guilds[guild.id]
-  })
+
   return {client, guild, bot, kody, talkToBotsChannel}
 }
 
@@ -79,7 +77,7 @@ function createUser(client, username, guild) {
   return newUser
 }
 
-function waitExpect(expectation, {timeout = 3000, interval = 1000}) {
+function waitUntil(expectation, {timeout = 3000, interval = 1000}) {
   if (interval < 1) interval = 1
   const maxTries = Math.ceil(timeout / interval)
   let tries = 0
@@ -105,4 +103,9 @@ function waitExpect(expectation, {timeout = 3000, interval = 1000}) {
   })
 }
 
-module.exports = {makeFakeClient, createUser, guilds, waitExpect}
+module.exports = {
+  makeFakeClient,
+  createUser,
+  waitUntil,
+  DiscordManager,
+}

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -84,10 +84,9 @@ async function makeFakeClient() {
   }
 
   function cleanup() {
-    DiscordManager.channels = {}
-    DiscordManager.guilds = {}
+    DiscordManager.cleanup()
   }
-
+  DiscordManager.clients.push(client)
   return {
     client,
     guild,

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -77,7 +77,7 @@ async function makeFakeClient() {
     user = kody,
     content = 'content',
     channel = talkToBotsChannel,
-  }) {
+  } = {}) {
     const userMessage = new Discord.Message(
       client,
       {
@@ -102,7 +102,7 @@ async function makeFakeClient() {
   }
 }
 
-function waitUntil(expectation, {timeout = 3000, interval = 1000}) {
+function waitUntil(expectation, {timeout = 3000, interval = 1000} = {}) {
   if (interval < 1) interval = 1
   const maxTries = Math.ceil(timeout / interval)
   let tries = 0

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -1,52 +1,34 @@
+/* eslint-disable no-await-in-loop */
 const Discord = require('discord.js')
 const {SnowflakeUtil} = require('discord.js')
 const DiscordManager = require('./DiscordManager')
 
-async function makeFakeClient() {
-  const client = new Discord.Client()
-  Object.assign(client, {
-    token: process.env.DISCORD_BOT_TOKEN,
-    user: new Discord.ClientUser(client, {
-      id: SnowflakeUtil.generate(),
-      bot: true,
-      username: 'kcd',
-    }),
-  })
-  const guild = new Discord.Guild(client, {
-    id: SnowflakeUtil.generate(),
-    name: 'KCD',
-  })
-  guild.messages = []
-  DiscordManager.guilds[guild.id] = guild
-  const everyoneRole = new Discord.Role(
-    client,
-    // the everyone role has the same id as the guild.
-    {id: guild.id, name: '@everyone'},
-    guild,
-  )
-  client.guilds.cache.set(guild.id, guild)
-  guild.roles.cache.set(guild.id, everyoneRole)
+async function createEmojis(guild) {
+  const emojies = [
+    'jest',
+    'react',
+    'reactquery',
+    'nextjs',
+    'gatsby',
+    'remix',
+    'graphql',
+    'html',
+    'css',
+    'js',
+    'node',
+    'msw',
+    'cypress',
+    'ReactTestingLibrary',
+    'DOMTestingLibrary',
+  ]
+  const guildEmojis = {}
+  for (const emoji of emojies) {
+    guildEmojis[emoji] = await guild.emojis.create(Buffer.from(emoji), emoji)
+  }
+  return guildEmojis
+}
 
-  const memberRole = new Discord.Role(
-    client,
-    {id: SnowflakeUtil.generate(), name: 'Member'},
-    guild,
-  )
-  guild.roles.cache.set(memberRole.id, memberRole)
-
-  let bot = new Discord.GuildMember(client, {bot: true, username: 'kcd'}, guild)
-  bot.user = new Discord.User(client, {id: SnowflakeUtil.generate()})
-  bot = await bot.roles.add([memberRole])
-  guild.members.cache.set(bot.id, bot)
-
-  let kody = new Discord.GuildMember(client, {nick: 'kody'}, guild)
-  kody.user = new Discord.User(client, {
-    id: SnowflakeUtil.generate(),
-    username: 'kodykoala',
-  })
-  kody = await kody.roles.add([memberRole])
-  guild.members.cache.set(kody.id, kody)
-
+async function createChannels(client, guild) {
   const talkToBotsChannel = await guild.channels.create('🤖-talk-to-bots')
   guild.channels.cache.set(talkToBotsChannel.id, talkToBotsChannel)
 
@@ -55,21 +37,143 @@ async function makeFakeClient() {
   })
   guild.channels.cache.set(privateChatCategory.id, privateChatCategory)
 
-  function createUser(username) {
+  const onBoardingCategory = await guild.channels.create('Onboarding-1', {
+    type: 'CATEGORY',
+  })
+  guild.channels.cache.set(onBoardingCategory.id, onBoardingCategory)
+
+  const introductionChannel = await guild.channels.create('👶-introductions')
+  guild.channels.cache.set(introductionChannel.id, introductionChannel)
+
+  const botsOnlyChannel = await guild.channels.create('🤖-bots-only')
+  guild.channels.cache.set(botsOnlyChannel.id, botsOnlyChannel)
+
+  const officeHoursVoiceChannel = await guild.channels.create(
+    `🏫 Kent's Office Hours`,
+    {
+      type: 'VOICE',
+    },
+  )
+  guild.channels.cache.set(officeHoursVoiceChannel.id, officeHoursVoiceChannel)
+
+  const officeHoursChannel = await guild.channels.create(`🏫-office-hours`)
+  guild.channels.cache.set(officeHoursChannel.id, officeHoursChannel)
+
+  const kentLiveVoiceChannel = await guild.channels.create(`💻-kent-live`, {
+    type: 'VOICE',
+  })
+  guild.channels.cache.set(kentLiveVoiceChannel.id, kentLiveVoiceChannel)
+
+  const kentLiveChannel = await guild.channels.create(`💻-kent-live`)
+  guild.channels.cache.set(kentLiveChannel.id, kentLiveChannel)
+
+  return {
+    kentLiveChannel,
+    kentLiveVoiceChannel,
+    officeHoursChannel,
+    officeHoursVoiceChannel,
+    botsOnlyChannel,
+    introductionChannel,
+    onBoardingCategory,
+    privateChatCategory,
+    talkToBotsChannel,
+  }
+}
+
+function createRoles(client, guild) {
+  const everyoneRole = new Discord.Role(
+    client,
+    {id: guild.id, name: '@everyone'},
+    guild,
+  )
+  guild.roles.cache.set(guild.id, everyoneRole)
+
+  const officeHoursRole = new Discord.Role(
+    client,
+    {id: SnowflakeUtil.generate(), name: 'Notify: Office Hours'},
+    guild,
+  )
+  guild.roles.cache.set(officeHoursRole.id, officeHoursRole)
+
+  const liveStreamRole = new Discord.Role(
+    client,
+    {id: SnowflakeUtil.generate(), name: 'Notify: Kent Live'},
+    guild,
+  )
+  guild.roles.cache.set(liveStreamRole.id, liveStreamRole)
+
+  const unconfirmedRole = new Discord.Role(
+    client,
+    {id: SnowflakeUtil.generate(), name: 'Unconfirmed Member'},
+    guild,
+  )
+  guild.roles.cache.set(unconfirmedRole.id, unconfirmedRole)
+
+  const memberRole = new Discord.Role(
+    client,
+    {id: SnowflakeUtil.generate(), name: 'Member'},
+    guild,
+  )
+  guild.roles.cache.set(memberRole.id, memberRole)
+
+  const newConfirmedMemberRole = new Discord.Role(
+    client,
+    {id: SnowflakeUtil.generate(), name: 'New confirmed member'},
+    guild,
+  )
+  guild.roles.cache.set(newConfirmedMemberRole.id, newConfirmedMemberRole)
+
+  return {
+    memberRole,
+    unconfirmedRole,
+    liveStreamRole,
+    officeHoursRole,
+    everyoneRole,
+    newConfirmedMemberRole,
+  }
+}
+
+async function makeFakeClient() {
+  const client = new Discord.Client()
+  Object.assign(client, {
+    token: process.env.DISCORD_BOT_TOKEN,
+    user: new Discord.ClientUser(client, {
+      id: SnowflakeUtil.generate(),
+      bot: true,
+      username: 'BOT',
+    }),
+  })
+  const guild = new Discord.Guild(client, {
+    id: SnowflakeUtil.generate(),
+    name: 'KCD',
+  })
+
+  DiscordManager.guilds[guild.id] = guild
+  client.guilds.cache.set(guild.id, guild)
+
+  const {memberRole} = createRoles(client, guild)
+  const defaultChannels = await createChannels(client, guild)
+  await createEmojis(guild)
+
+  async function createUser(username, options = {}) {
     const newUser = new Discord.GuildMember(client, {nick: username}, guild)
     newUser.user = new Discord.User(client, {
       id: SnowflakeUtil.generate(),
       username,
-      roles: [memberRole],
+      discriminator: client.users.cache.size,
+      ...options,
     })
     guild.members.cache.set(newUser.id, newUser)
+    await newUser.roles.add(memberRole)
     return newUser
   }
 
-  function addUserMessage({
+  const kody = await createUser('kody')
+
+  function sendFromUser({
     user = kody,
     content = 'content',
-    channel = talkToBotsChannel,
+    channel = defaultChannels.talkToBotsChannel,
   } = {}) {
     const userMessage = new Discord.Message(
       client,
@@ -81,6 +185,22 @@ async function makeFakeClient() {
       channel,
     )
     channel.messages.cache.set(userMessage.id, userMessage)
+    return userMessage
+  }
+
+  function reactFromUser({user = kody, message, reactionName = 'react'} = {}) {
+    const emoji = guild.emojis.cache.find(({name}) => reactionName === name)
+    let re = message.reactions.cache.get(emoji.name)
+    if (!re) {
+      re = {
+        message,
+        emoji: {name: emoji.name},
+        users: {cache: new Discord.Collection()},
+      }
+      message.reactions.cache.set(emoji.name, re)
+    }
+    re.users.cache.set(user.id, user)
+    return message
   }
 
   function cleanup() {
@@ -90,11 +210,12 @@ async function makeFakeClient() {
   return {
     client,
     guild,
-    bot,
+    bot: client.user,
     kody,
-    talkToBotsChannel,
+    defaultChannels,
     createUser,
-    addUserMessage,
+    sendFromUser,
+    reactFromUser,
     cleanup,
   }
 }

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -4,11 +4,8 @@ const DiscordManager = require('./DiscordManager')
 
 async function makeFakeClient() {
   const client = new Discord.Client()
-  client.login(process.env.DISCORD_BOT_TOKEN)
+  client.token = process.env.DISCORD_BOT_TOKEN
   Object.assign(client, {
-    channels: new Discord.ChannelManager(client),
-    guilds: new Discord.GuildManager(client),
-    users: new Discord.UserManager(client),
     user: new Discord.ClientUser(client, {
       id: SnowflakeUtil.generate(),
       bot: true,

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -34,24 +34,20 @@ async function makeFakeClient() {
   )
   guild.roles.cache.set(memberRole.id, memberRole)
 
-  const bot = new Discord.GuildMember(
-    client,
-    {bot: true, username: 'kcd', roles: [memberRole]},
-    guild,
-  )
+  let bot = new Discord.GuildMember(client, {bot: true, username: 'kcd'}, guild)
   bot.user = new Discord.User(client, {id: SnowflakeUtil.generate()})
+  bot = await bot.roles.add([memberRole])
   guild.members.cache.set(bot.id, bot)
 
-  const kody = new Discord.GuildMember(client, {nick: 'kody'}, guild)
+  let kody = new Discord.GuildMember(client, {nick: 'kody'}, guild)
   kody.user = new Discord.User(client, {
     id: SnowflakeUtil.generate(),
     username: 'kodykoala',
-    roles: [memberRole],
   })
+  kody = await kody.roles.add([memberRole])
   guild.members.cache.set(kody.id, kody)
 
   const talkToBotsChannel = await guild.channels.create('🤖-talk-to-bots')
-  jest.spyOn(talkToBotsChannel, 'send')
   guild.channels.cache.set(talkToBotsChannel.id, talkToBotsChannel)
 
   const privateChatCategory = await guild.channels.create('PRIVATE CHAT', {
@@ -87,6 +83,11 @@ async function makeFakeClient() {
     channel.messages.cache.set(userMessage.id, userMessage)
   }
 
+  function cleanup() {
+    DiscordManager.channels = {}
+    DiscordManager.guilds = {}
+  }
+
   return {
     client,
     guild,
@@ -95,6 +96,7 @@ async function makeFakeClient() {
     talkToBotsChannel,
     createUser,
     addUserMessage,
+    cleanup,
   }
 }
 

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -4,8 +4,8 @@ const DiscordManager = require('./DiscordManager')
 
 async function makeFakeClient() {
   const client = new Discord.Client()
-  client.token = process.env.DISCORD_BOT_TOKEN
   Object.assign(client, {
+    token: process.env.DISCORD_BOT_TOKEN,
     user: new Discord.ClientUser(client, {
       id: SnowflakeUtil.generate(),
       bot: true,


### PR DESCRIPTION
I have removed the old mock implementation when a message will be sent. 

**What**: 
1. I have improved the test experience using MSW, removing the mock on message sent.
2. I have added tests for private-chat
3. Fixed a bug, when checking for the last message the bot was not excluded 
4. I have changed the ids using discord method `SnowflakeUtil.generate`
5. Fix a bug with kif command. When the user doesn't have a nickname we should use the username
6. Refactor onboarding tests
 
<!-- Why are these changes necessary? -->

**Why**: 
To make sure that everything will works

**How**:

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
