### PR TITLE
feat: blog random command

### DIFF
--- a/src/commands/command-fns/__tests__/blog.js
+++ b/src/commands/command-fns/__tests__/blog.js
@@ -156,3 +156,10 @@ test('should show the first 10 results if there are more', async () => {
       <https://kentcdodds.com/blog/should-i-write-a-test-or-fix-a-bug>"
   `)
 })
+
+test('should return an article link for random', async () => {
+  const {messages} = await setup(`random`)
+
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toContain(`https://kentcdodds.com/blog/`)
+})

--- a/src/commands/command-fns/blog.js
+++ b/src/commands/command-fns/blog.js
@@ -50,6 +50,9 @@ This is the list of the last 10 articles on the blog:
 ${printArticles(lastArticles)}
       `.trim(),
     )
+  } else if (args === 'random') {
+    const randomIndex = Math.floor(Math.random() * (articles.length - 0) + 0)
+    return message.channel.send(`${articles[randomIndex].productionUrl}`)
   } else if (args) {
     const filteredArticles = searchArticles(articles, args)
     if (filteredArticles.length === 0) {
@@ -86,6 +89,8 @@ blog.description = `Find articles on Kent's blog: <https://kentcdodds.com/blog>`
 blog.help = message => {
   const commandsList = [
     `- Send \`?blog last\` for the last 10 articles.`,
+    `- Send \`?blog latest\` for the latest published article.`,
+    `- Send \`?blog random\` to get a random article.`,
     `- Send \`?blog your search string\` to find articles by categories, keyword, title and description.`,
   ]
   return message.channel.send(


### PR DESCRIPTION
**What**: Feature: `?blog random` command to return a random article

**Why**: Discover more of Kent's blog posts :)

**How**: Just returning a random index from the array of articles

**Checklist**:
- [ ] Documentation
- [x] Tests
- [x] Ready to be merged

Ready to be merged as in: I haven't spun up an instance to test this but I have written a test and I can't see there being an issue, it's straight forward.

Added `?blog latest` to help as well while at there as I spotted that wasn't reported.