### PR TITLE
feat: support new extend command for private-chat

### DIFF
--- a/src/commands/command-fns/__tests__/private-chat.js
+++ b/src/commands/command-fns/__tests__/private-chat.js
@@ -13,51 +13,68 @@ async function createPrivateChat(mentionedUsernames = []) {
     sendFromUser,
     createUser,
   } = await makeFakeClient()
+  const categoryPrivateChat = getCategory(guild, {name: 'private chat'})
   const sentMessageUser = await createUser('sentMessageUser')
+
+  const mentionedUsers = (
+    await Promise.all(mentionedUsernames.map(username => createUser(username)))
+  ).map(guildMember => guildMember.user)
+
   const message = new Discord.Message(
     client,
     {
       id: SnowflakeUtil.generate(),
-      content: '?private-chat',
+      content: `?private-chat ${mentionedUsers
+        .map(user => `<@!${user.id}>`)
+        .join(' ')}`,
       author: sentMessageUser.user,
     },
     defaultChannels.talkToBotsChannel,
   )
-  const mentionedUsers = (
-    await Promise.all(mentionedUsernames.map(username => createUser(username)))
-  ).map(guildMember => guildMember.user)
+
   Object.assign(message, {
     mentions: new Discord.MessageMentions(message, mentionedUsers, [], false),
   })
 
   await privateChat(message)
-  const botsMessages = Array.from(
-    defaultChannels.talkToBotsChannel.messages.cache.values(),
-  )
-  return {
-    client,
-    message,
-    guild,
-    botsMessages,
-    channelMembers: [sentMessageUser, ...mentionedUsers],
-    sendFromUser,
-  }
-}
+  const getBotsMessages = () =>
+    Array.from(
+      defaultChannels.talkToBotsChannel.messages.cache.values(),
+    ).filter(talkToBotsChannelMessage => talkToBotsChannelMessage.author.bot)
 
-function getPrivateChannels(guild) {
-  const categoryPrivateChat = getCategory(guild, {name: 'private chat'})
-  return Array.from(
+  const privateChannels = Array.from(
     guild.channels.cache
       .filter(channel => channel.parent?.id === categoryPrivateChat.id)
       .values(),
   )
+
+  async function executeCommand(author, command, ...rest) {
+    const commandMessage = await sendFromUser({
+      user: author,
+      content: `?private-chat ${command} ${rest.join(' ')}`,
+      channel: privateChannels[0],
+    })
+    return privateChat(commandMessage)
+  }
+
+  return {
+    client,
+    message,
+    guild,
+    getBotsMessages,
+    channelMembers: [sentMessageUser, ...mentionedUsers],
+    sendFromUser,
+    privateChannels,
+    executeCommand,
+  }
 }
 
 test('should create a private chat for two users', async () => {
-  const {guild, channelMembers, botsMessages} = await createPrivateChat([
-    'mentionedUser',
-  ])
-  const privateChannels = getPrivateChannels(guild)
+  const {
+    channelMembers,
+    getBotsMessages,
+    privateChannels,
+  } = await createPrivateChat(['mentionedUser'])
 
   expect(privateChannels).toHaveLength(1)
   const privateChannel = privateChannels[0]
@@ -75,6 +92,7 @@ I'm the bot that created this channel for you. The channel will be deleted after
 `.trim(),
   )
 
+  const botsMessages = getBotsMessages()
   expect(botsMessages).toHaveLength(1)
   expect(botsMessages[0].content).toEqual(
     `I've created <#${privateChannel.id}> for you folks to talk privately. Cheers!`,
@@ -82,12 +100,11 @@ I'm the bot that created this channel for you. The channel will be deleted after
 })
 
 test('should create a private chat for more than two users', async () => {
-  const {guild} = await createPrivateChat([
+  const {privateChannels} = await createPrivateChat([
     'mentionedUser',
     'mentionedUser2',
     'mentionedUser3',
   ])
-  const privateChannels = getPrivateChannels(guild)
 
   expect(privateChannels).toHaveLength(1)
   const privateChannel = privateChannels[0]
@@ -98,8 +115,13 @@ test('should create a private chat for more than two users', async () => {
 
 test('should delete the private chat after 10 minutes of inactivity', async () => {
   jest.spyOn(Date, 'now').mockImplementation(() => 1598947200000) // 10:00 UTC+2
-  const {guild} = await createPrivateChat(['mentionedUser'])
-  const privateChannel = getPrivateChannels(guild)[0]
+  const {
+    guild,
+    privateChannels,
+    sendFromUser,
+    channelMembers,
+  } = await createPrivateChat(['mentionedUser'])
+  const privateChannel = privateChannels[0]
   jest.spyOn(Date, 'now').mockImplementation(() => 1598947380000) //10:03:00 UTC+2
   await cleanup(guild)
   expect(privateChannel.messages.cache.size).toEqual(1)
@@ -112,11 +134,18 @@ test('should delete the private chat after 10 minutes of inactivity', async () =
   )
   // run this to check that no other warning message are sent
   await cleanup(guild)
+  await sendFromUser({user: channelMembers[0].user, channel: privateChannel})
 
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598947801000) //10:10:01 UTC+2
-
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598947802000) //10:10:02 UTC+2
   await cleanup(guild)
-  expect(privateChannel.messages.cache.size).toEqual(3)
+  expect(privateChannel.messages.cache.size).toEqual(4)
+  expect(privateChannel.lastMessage.content).toEqual(
+    `This channel will be deleted in 5 minutes for the following reason: deleted for inactivity 🚶‍♀️`,
+  )
+
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598948103000) //10:15:03 UTC+2
+  await cleanup(guild)
+  expect(privateChannel.messages.cache.size).toEqual(5)
   expect(privateChannel.lastMessage.content).toEqual(
     `
 This channel is getting deleted for the following reason: deleted for inactivity 🚶‍♀️
@@ -132,10 +161,13 @@ This channel is getting deleted for the following reason: deleted for inactivity
 
 test('should delete the private chat after 60 minutes', async () => {
   jest.spyOn(Date, 'now').mockImplementation(() => 1598947200000) // 10:00 UTC+2
-  const {guild, channelMembers, sendFromUser} = await createPrivateChat([
-    'mentionedUser',
-  ])
-  const privateChannel = getPrivateChannels(guild)[0]
+  const {
+    guild,
+    channelMembers,
+    sendFromUser,
+    privateChannels,
+  } = await createPrivateChat(['mentionedUser'])
+  const privateChannel = privateChannels[0]
 
   jest.spyOn(Date, 'now').mockImplementation(() => 1598947800000) //10:15:00 UTC+2
   sendFromUser({user: channelMembers[0].user, channel: privateChannel})
@@ -167,22 +199,62 @@ This channel is getting deleted for the following reason: deleted for end of lif
 })
 
 test('should not create a chat without mentioned member', async () => {
-  const {botsMessages} = await createPrivateChat()
+  const {getBotsMessages} = await createPrivateChat()
+
+  const botsMessages = getBotsMessages()
   expect(botsMessages).toHaveLength(1)
   expect(botsMessages[0].content).toEqual(
     'You should mention at least one other member.',
   )
 })
 
+test('should give an error if the command not exist', async () => {
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598947200000) // 10:00 UTC+2
+  const {
+    channelMembers,
+    executeCommand,
+    privateChannels,
+  } = await createPrivateChat(['mentionedUser'])
+  const privateChannel = privateChannels[0]
+
+  await executeCommand(channelMembers[0].user, 'not-exist')
+  expect(privateChannel.messages.cache.size).toEqual(3)
+  expect(privateChannel.lastMessage.content).toEqual(
+    'The command is not available. use `?private-chat help` to know more about the available commands',
+  )
+})
+
 test('should give an error trying to create a chat for the same members', async () => {
-  const {message, guild} = await createPrivateChat(['mentionedUser'])
-  const privateChannel = getPrivateChannels(guild)[0]
+  const {message, privateChannels, getBotsMessages} = await createPrivateChat([
+    'mentionedUser',
+  ])
+  const privateChannel = privateChannels[0]
   await privateChat(message)
 
-  const botsMessages = Array.from(message.channel.messages.cache.values())
+  const botsMessages = getBotsMessages()
   expect(botsMessages).toHaveLength(2)
   expect(botsMessages[1].content).toEqual(
     `There is already a chat for the same members <#${privateChannel.id}>`,
+  )
+})
+
+test('should give an error trying to send a command not in a private chat', async () => {
+  const {
+    channelMembers,
+    sendFromUser,
+    getBotsMessages,
+  } = await createPrivateChat(['mentionedUser'])
+
+  const userMessage = await sendFromUser({
+    user: channelMembers[0].user,
+    content: '?private-chat extend 10',
+  })
+  await privateChat(userMessage)
+
+  const botsMessages = getBotsMessages()
+  expect(botsMessages).toHaveLength(2)
+  expect(botsMessages[1].content).toEqual(
+    `The command extend can be used only in private chat`,
   )
 })
 
@@ -211,9 +283,94 @@ test('should not create a private-chat with yourself', async () => {
 
   const botsMessages = Array.from(
     defaultChannels.talkToBotsChannel.messages.cache.values(),
-  )
+  ).filter(talkToBotsChannelMessage => talkToBotsChannelMessage.author.bot)
   expect(botsMessages).toHaveLength(1)
   expect(botsMessages[0].content).toEqual(
     `You should mention at least one other member.`,
   )
+})
+
+test('should not extend the liftime if has been passed an invalid time', async () => {
+  const {
+    channelMembers,
+    privateChannels,
+    executeCommand,
+  } = await createPrivateChat(['mentionedUser'])
+  const privateChannel = privateChannels[0]
+
+  const attempts = [
+    {
+      expectedCountMessages: 3,
+      extendTime: 0,
+    },
+    {
+      expectedCountMessages: 5,
+      extendTime: null,
+    },
+    {
+      expectedCountMessages: 7,
+      extendTime: 'invalid',
+    },
+  ]
+
+  for (const attempt of attempts) {
+    // eslint-disable-next-line no-await-in-loop
+    await executeCommand(channelMembers[0].user, 'extend', attempt.extendTime)
+
+    expect(privateChannel.messages.cache.size).toEqual(
+      attempt.expectedCountMessages,
+    )
+    expect(privateChannel.lastMessage.content).toEqual(
+      'You have to pass an extended time in minutes. Example: `?private-chat extend 10`',
+    )
+  }
+})
+
+test('should extend the time of the private-chat', async () => {
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598947200000) // 10:00 UTC+2
+  const {
+    guild,
+    channelMembers,
+    sendFromUser,
+    privateChannels,
+    executeCommand,
+  } = await createPrivateChat(['mentionedUser'])
+  const privateChannel = privateChannels[0]
+
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598950501000) //10:55:01 UTC+2
+  sendFromUser({user: channelMembers[0].user, channel: privateChannel})
+  await cleanup(guild)
+  expect(privateChannel.messages.cache.size).toEqual(3)
+  expect(privateChannel.lastMessage.content).toEqual(
+    `This channel will be deleted in 5 minutes for the following reason: deleted for end of life 👻`,
+  )
+
+  await executeCommand(channelMembers[0].user, 'extend', '10')
+  expect(privateChannel.messages.cache.size).toEqual(4)
+  expect(privateChannel.lastMessage.content).toEqual(
+    `The lifetime of the channel has been extended of 10 minutes more ⏱`,
+  )
+
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598951101000) //11:05:01 UTC+2
+
+  await cleanup(guild)
+  expect(privateChannel.messages.cache.size).toEqual(5)
+  expect(privateChannel.lastMessage.content).toEqual(
+    `This channel will be deleted in 5 minutes for the following reason: deleted for end of life 👻`,
+  )
+
+  jest.spyOn(Date, 'now').mockImplementation(() => 1598951401000) //11:10:01 UTC+2
+  await cleanup(guild)
+  expect(privateChannel.messages.cache.size).toEqual(6)
+  expect(privateChannel.lastMessage.content).toEqual(
+    `
+This channel is getting deleted for the following reason: deleted for end of life 👻
+  
+  Goodbye 👋
+    `.trim(),
+  )
+
+  await waitUntil(() => {
+    expect(privateChannel.deleted).toBeTruthy()
+  })
 })

--- a/src/commands/command-fns/__tests__/private-chat.js
+++ b/src/commands/command-fns/__tests__/private-chat.js
@@ -114,7 +114,7 @@ test('should create a private chat for more than two users', async () => {
 })
 
 test('should delete the private chat after 10 minutes of inactivity', async () => {
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598947200000) // 10:00 UTC+2
+  Date.now.mockImplementation(() => 1598947200000) // 10:00 UTC+2
   const {
     guild,
     privateChannels,
@@ -122,11 +122,11 @@ test('should delete the private chat after 10 minutes of inactivity', async () =
     channelMembers,
   } = await createPrivateChat(['mentionedUser'])
   const privateChannel = privateChannels[0]
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598947380000) //10:03:00 UTC+2
+  Date.now.mockImplementation(() => 1598947380000) //10:03:00 UTC+2
   await cleanup(guild)
   expect(privateChannel.messages.cache.size).toEqual(1)
 
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598947501000) //10:05:01 UTC+2
+  Date.now.mockImplementation(() => 1598947501000) //10:05:01 UTC+2
   await cleanup(guild)
   expect(privateChannel.messages.cache.size).toEqual(2)
   expect(privateChannel.lastMessage.content).toEqual(
@@ -136,14 +136,14 @@ test('should delete the private chat after 10 minutes of inactivity', async () =
   await cleanup(guild)
   await sendFromUser({user: channelMembers[0].user, channel: privateChannel})
 
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598947802000) //10:10:02 UTC+2
+  Date.now.mockImplementation(() => 1598947802000) //10:10:02 UTC+2
   await cleanup(guild)
   expect(privateChannel.messages.cache.size).toEqual(4)
   expect(privateChannel.lastMessage.content).toEqual(
     `This channel will be deleted in 5 minutes for the following reason: deleted for inactivity 🚶‍♀️`,
   )
 
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598948103000) //10:15:03 UTC+2
+  Date.now.mockImplementation(() => 1598948103000) //10:15:03 UTC+2
   await cleanup(guild)
   expect(privateChannel.messages.cache.size).toEqual(5)
   expect(privateChannel.lastMessage.content).toEqual(
@@ -160,7 +160,7 @@ This channel is getting deleted for the following reason: deleted for inactivity
 })
 
 test('should delete the private chat after 60 minutes', async () => {
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598947200000) // 10:00 UTC+2
+  Date.now.mockImplementation(() => 1598947200000) // 10:00 UTC+2
   const {
     guild,
     channelMembers,
@@ -169,9 +169,9 @@ test('should delete the private chat after 60 minutes', async () => {
   } = await createPrivateChat(['mentionedUser'])
   const privateChannel = privateChannels[0]
 
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598947800000) //10:15:00 UTC+2
+  Date.now.mockImplementation(() => 1598947800000) //10:15:00 UTC+2
   sendFromUser({user: channelMembers[0].user, channel: privateChannel})
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598950501000) //10:55:01 UTC+2
+  Date.now.mockImplementation(() => 1598950501000) //10:55:01 UTC+2
   sendFromUser({user: channelMembers[0].user, channel: privateChannel})
   await cleanup(guild)
   expect(privateChannel.messages.cache.size).toEqual(4)
@@ -181,7 +181,7 @@ test('should delete the private chat after 60 minutes', async () => {
   // run this to check that no other warning message are sent
   await cleanup(guild)
 
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598950801000) //11:00:01 UTC+2
+  Date.now.mockImplementation(() => 1598950801000) //11:00:01 UTC+2
 
   await cleanup(guild)
   expect(privateChannel.messages.cache.size).toEqual(5)
@@ -209,7 +209,7 @@ test('should not create a chat without mentioned member', async () => {
 })
 
 test('should give an error if the command not exist', async () => {
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598947200000) // 10:00 UTC+2
+  Date.now.mockImplementation(() => 1598947200000) // 10:00 UTC+2
   const {
     channelMembers,
     executeCommand,
@@ -327,7 +327,7 @@ test('should not extend the liftime if has been passed an invalid time', async (
 })
 
 test('should extend the time of the private-chat', async () => {
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598947200000) // 10:00 UTC+2
+  Date.now.mockImplementation(() => 1598947200000) // 10:00 UTC+2
   const {
     guild,
     channelMembers,
@@ -337,7 +337,7 @@ test('should extend the time of the private-chat', async () => {
   } = await createPrivateChat(['mentionedUser'])
   const privateChannel = privateChannels[0]
 
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598950501000) //10:55:01 UTC+2
+  Date.now.mockImplementation(() => 1598950501000) //10:55:01 UTC+2
   sendFromUser({user: channelMembers[0].user, channel: privateChannel})
   await cleanup(guild)
   expect(privateChannel.messages.cache.size).toEqual(3)
@@ -351,7 +351,7 @@ test('should extend the time of the private-chat', async () => {
     `The lifetime of the channel has been extended of 10 minutes more ⏱`,
   )
 
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598951101000) //11:05:01 UTC+2
+  Date.now.mockImplementation(() => 1598951101000) //11:05:01 UTC+2
 
   await cleanup(guild)
   expect(privateChannel.messages.cache.size).toEqual(5)
@@ -359,7 +359,7 @@ test('should extend the time of the private-chat', async () => {
     `This channel will be deleted in 5 minutes for the following reason: deleted for end of life 👻`,
   )
 
-  jest.spyOn(Date, 'now').mockImplementation(() => 1598951401000) //11:10:01 UTC+2
+  Date.now.mockImplementation(() => 1598951401000) //11:10:01 UTC+2
   await cleanup(guild)
   expect(privateChannel.messages.cache.size).toEqual(6)
   expect(privateChannel.lastMessage.content).toEqual(

--- a/src/commands/command-fns/__tests__/private-chat.js
+++ b/src/commands/command-fns/__tests__/private-chat.js
@@ -337,6 +337,10 @@ test('should extend the time of the private-chat', async () => {
   } = await createPrivateChat(['mentionedUser'])
   const privateChannel = privateChannels[0]
 
+  expect(privateChannel.topic).toMatchInlineSnapshot(
+    `"Private chat for mentionedUser and sentMessageUser self-destruct at Tue, 01 Sep 2020 09:00:00 GMT"`,
+  )
+
   Date.now.mockImplementation(() => 1598950501000) //10:55:01 UTC+2
   sendFromUser({user: channelMembers[0].user, channel: privateChannel})
   await cleanup(guild)
@@ -346,6 +350,9 @@ test('should extend the time of the private-chat', async () => {
   )
 
   await executeCommand(channelMembers[0].user, 'extend', '10')
+  expect(privateChannel.topic).toMatchInlineSnapshot(
+    `"Private chat for sentMessageUser and mentionedUser self-destruct at Tue, 01 Sep 2020 09:10:00 GMT"`,
+  )
   expect(privateChannel.messages.cache.size).toEqual(4)
   expect(privateChannel.lastMessage.content).toEqual(
     `The lifetime of the channel has been extended of 10 minutes more ⏱`,

--- a/src/commands/command-fns/private-chat.js
+++ b/src/commands/command-fns/private-chat.js
@@ -1,13 +1,22 @@
 const Discord = require('discord.js')
+const {MessageMentions} = require('discord.js')
 const {
   privateChannelPrefix,
   listify,
   sendBotMessageReply,
   getCategory,
   getMember,
+  getCommandArgs,
+  timeToMs,
 } = require('../utils')
+const {
+  defaultLifeTimeMinute,
+  warningStepMinute,
+  maxInactiveTimeMinute,
+  eolReason,
+} = require('../../private-chat')
 
-async function privateChat(message) {
+async function createChat(message) {
   const mentionedMembers = Array.from(message.mentions.members.values()).filter(
     user => user.user.id !== message.member.id,
   )
@@ -81,7 +90,7 @@ async function privateChat(message) {
   const channel = await message.guild.channels.create(
     `${privateChannelPrefix}${channelSuffix}`,
     {
-      topic: `Private Chat`,
+      topic: `self-destruct in ${defaultLifeTimeMinute} minutes`,
       parent: categoryPrivateChat,
       permissionOverwrites: [
         {
@@ -93,19 +102,100 @@ async function privateChat(message) {
       ],
     },
   )
-  await channel.send(
-    `
+  return Promise.all([
+    channel.send(
+      `
 Hello ${listify(mentionedMembers, {stringify: member => member})} 👋
 
 I'm the bot that created this channel for you. The channel will be deleted after 1 hour or after 10 minutes for inactivity. Enjoy 🗣
 
 > Please note that the KCD Discord Server Owners and Admins *can* see this chat. So if you want to be *completely* private, then you'll need to take your communication elsewhere.
     `.trim(),
-  )
-  await message.channel.send(
-    `I've created ${channel} for you folks to talk privately. Cheers!`,
+    ),
+    message.channel.send(
+      `I've created ${channel} for you folks to talk privately. Cheers!`,
+    ),
+  ])
+}
+
+async function extendTime(message, extendedTime) {
+  const parsedTime = parseInt(extendedTime, 10)
+  if (parsedTime > 0) {
+    const privateChannel = message.channel
+    const match = privateChannel.topic.match(
+      /self-destruct in (?<time>\d+) minutes/i,
+    )
+    let currentTime = defaultLifeTimeMinute
+    if (match) currentTime = parseInt(match.groups.time, 10)
+
+    const newLifetime = currentTime + parsedTime
+    await privateChannel.setTopic(
+      `self-destruct in ${newLifetime} minutes`,
+      'extend lifetime',
+    )
+    const channelCreateDate = privateChannel.createdAt
+    const timeSinceChannelCreation = Date.now() - channelCreateDate
+
+    if (
+      timeSinceChannelCreation <
+      timeToMs.minutes(newLifetime) - timeToMs.minutes(warningStepMinute)
+    ) {
+      const allMessages = Array.from(
+        (await message.channel.messages.fetch()).values(),
+      )
+      const botMessages = allMessages.filter(
+        channelMessage => channelMessage.author?.bot,
+      )
+
+      const eolWarningMessage = botMessages.find(
+        botMessage =>
+          botMessage.content.includes(`${warningStepMinute} minutes`) &&
+          botMessage.content.includes(eolReason),
+      )
+      if (eolWarningMessage) {
+        await eolWarningMessage.delete({reason: 'extend lifetime'})
+      }
+    }
+    return message.channel.send(
+      `The lifetime of the channel has been extended of ${parsedTime} minutes more ⏱`,
+    )
+  }
+
+  return message.channel.send(
+    'You have to pass an extended time in minutes. Example: `?private-chat extend 10`',
   )
 }
+
+function privateChat(message) {
+  const privateChatSubcommand = {extend: extendTime}
+  const args = getCommandArgs(message.content).trim()
+  const privateChatArg = args
+    .replace(MessageMentions.USERS_PATTERN, '')
+    .trim()
+    .toLowerCase()
+  const [command, ...rest] = privateChatArg.split(' ')
+  if (command) {
+    if (command in privateChatSubcommand) {
+      const categoryPrivateChat = getCategory(message.guild, {
+        name: 'private chat',
+      })
+      if (message.channel.parent?.id === categoryPrivateChat.id) {
+        return privateChatSubcommand[command](message, ...rest)
+      } else {
+        return message.channel.send(
+          `The command ${command} can be used only in private chat`,
+        )
+      }
+    } else {
+      return message.channel.send(
+        'The command is not available. use `?private-chat help` to know more about the available commands',
+      )
+    }
+  } else {
+    return createChat(message)
+  }
+}
+
 privateChat.description =
   'Create a private channel with who you want. This channel is temporary.'
 privateChat.help = message =>
@@ -113,11 +203,10 @@ privateChat.help = message =>
     message,
     `
 Use this command to create a private chat with members of the server 🤫. 
-The chat will be deleted after 1 hour 👻 or if there is at least 10 minutes of inactivity 🚶‍♂️.
-
-Example of usage: \`?private-chat @User1 @User2\`
-
-This will create a private chat room for you and User1 and User2.
+The chat will be deleted after ${defaultLifeTimeMinute} minutes 👻 or if there is at least ${maxInactiveTimeMinute} minutes of inactivity 🚶‍♂️.
+The following commands are available:
+1. \`?private-chat @User1 @User2\`. This will create a private chat room for you and User1 and User2.
+2. \`?private-chat extend 10\`. This will extend the lifetime of the chat of 10 minutes. The command is available only in private chat.
     `.trim(),
   )
 

--- a/src/private-chat/cleanup.js
+++ b/src/private-chat/cleanup.js
@@ -1,15 +1,15 @@
 /* eslint-disable no-await-in-loop */
-const {getSend, sleep, getCategory} = require('../utils')
+const {getSend, sleep, getCategory, timeToMs} = require('../utils')
+
+const warningStepMinute = 5
+const defaultLifeTimeMinute = 60
+const maxInactiveTimeMinute = 10
+const forceDelayTimeTimute = 2
+const eolReason = 'deleted for end of life 👻'
+const inactivityReason = 'deleted for inactivity 🚶‍♀️'
 
 async function cleanup(guild) {
   const categoryPrivateChat = getCategory(guild, {name: 'private chat'})
-
-  const warningStep = 1000 * 60 * 5
-  const maxExistingTime = 1000 * 60 * 60
-  const maxInactiveTime = 1000 * 60 * 10
-  const forceDelayTime = 1000 * 60 * 2
-  const eolReason = 'deleted for end of life 👻'
-  const inactivityReason = 'deleted for inactivity 🚶‍♀️'
 
   const allActivePrivateChannels = Array.from(
     guild.channels.cache
@@ -25,7 +25,10 @@ async function cleanup(guild) {
 
   for (const channel of allActivePrivateChannels) {
     const channelCreateDate = channel.createdAt
-
+    const match = channel.topic.match(/self-destruct in (?<time>\d+) minutes/i)
+    let currentMaxExistingTime = timeToMs.minutes(defaultLifeTimeMinute)
+    if (match)
+      currentMaxExistingTime = timeToMs.minutes(parseInt(match.groups.time, 10))
     const timeSinceChannelCreation = Date.now() - channelCreateDate
 
     const allMessages = Array.from((await channel.messages.fetch()).values())
@@ -39,15 +42,23 @@ async function cleanup(guild) {
       timeSinceLastMessage = Date.now() - messages[0].createdTimestamp
     }
 
-    const hasInactiveWarned = botMessages.some(message => {
-      return (
-        message.content.includes('5 minutes') &&
-        message.content.includes(inactivityReason)
-      )
-    })
+    const hasInactiveWarned = allMessages
+      .reverse()
+      .reduce((hasWarned, message) => {
+        const isInactiveWarning =
+          message.content.includes(`${warningStepMinute} minutes`) &&
+          message.content.includes(inactivityReason) &&
+          message.author?.bot
+        if (isInactiveWarning) return true
+
+        if (!message.author?.bot) return false
+
+        return hasWarned
+      }, false)
+
     const hasEOLWarned = botMessages.some(
       message =>
-        message.content.includes('5 minutes') &&
+        message.content.includes(`${warningStepMinute} minutes`) &&
         message.content.includes(eolReason),
     )
     const isGettingDeleted = botMessages.some(message =>
@@ -57,11 +68,11 @@ async function cleanup(guild) {
     )
     const send = getSend(channel)
     if (
-      timeSinceChannelCreation > maxExistingTime ||
-      timeSinceLastMessage > maxInactiveTime
+      timeSinceChannelCreation > currentMaxExistingTime ||
+      timeSinceLastMessage > timeToMs.minutes(maxInactiveTimeMinute)
     ) {
       let reason
-      if (timeSinceChannelCreation > maxExistingTime) {
+      if (timeSinceChannelCreation > currentMaxExistingTime) {
         reason = eolReason
       } else {
         reason = inactivityReason
@@ -82,25 +93,33 @@ async function cleanup(guild) {
       // After two minute from deletion we try to delate the channel again
       // Maybe the server was stopped and the previous sleep was not finished
       if (
-        timeSinceChannelCreation - maxExistingTime > forceDelayTime ||
-        timeSinceLastMessage - maxInactiveTime > forceDelayTime
+        timeSinceChannelCreation - currentMaxExistingTime >
+          timeToMs.minutes(forceDelayTimeTimute) ||
+        timeSinceLastMessage - timeToMs.minutes(maxInactiveTimeMinute) >
+          timeToMs.minutes(forceDelayTimeTimute)
       ) {
         await channel.delete(reason)
       }
     } else if (
-      (timeSinceChannelCreation > maxExistingTime - warningStep ||
-        timeSinceLastMessage > maxInactiveTime - warningStep) &&
+      (timeSinceChannelCreation >
+        currentMaxExistingTime - timeToMs.minutes(warningStepMinute) ||
+        timeSinceLastMessage >
+          timeToMs.minutes(maxInactiveTimeMinute) -
+            timeToMs.minutes(warningStepMinute)) &&
       !hasInactiveWarned &&
       !hasEOLWarned
     ) {
       let reason
       if (
-        timeSinceChannelCreation > maxExistingTime - warningStep &&
+        timeSinceChannelCreation >
+          currentMaxExistingTime - timeToMs.minutes(warningStepMinute) &&
         !hasEOLWarned
       ) {
         reason = eolReason
       } else if (
-        timeSinceLastMessage > maxInactiveTime - warningStep &&
+        timeSinceLastMessage >
+          timeToMs.minutes(maxInactiveTimeMinute) -
+            timeToMs.minutes(warningStepMinute) &&
         !hasInactiveWarned
       ) {
         reason = inactivityReason
@@ -108,7 +127,7 @@ async function cleanup(guild) {
       if (reason) {
         await send(
           `
-This channel will be deleted in 5 minutes for the following reason: ${reason}
+This channel will be deleted in ${warningStepMinute} minutes for the following reason: ${reason}
         `.trim(),
         )
       }
@@ -116,4 +135,10 @@ This channel will be deleted in 5 minutes for the following reason: ${reason}
   }
 }
 
-module.exports = {cleanup}
+module.exports = {
+  cleanup,
+  warningStepMinute,
+  defaultLifeTimeMinute,
+  eolReason,
+  inactivityReason,
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -179,4 +179,5 @@ module.exports = {
   getSelfDestructTime,
   welcomeChannelPrefix,
   privateChannelPrefix,
+  timeToMs,
 }

--- a/tests/handlers/discord.js
+++ b/tests/handlers/discord.js
@@ -145,6 +145,17 @@ const handlers = [
       return res(ctx.status(200), ctx.json(message))
     },
   ),
+  rest.patch('*/api/:apiVersion/channels/:channelId', (req, res, ctx) => {
+    const channel = {
+      ...DiscordManager.channels[req.params.channelId],
+      ...req.body,
+    }
+
+    DiscordManager.guilds[channel.guild_id].client.actions.ChannelUpdate.handle(
+      channel,
+    )
+    return res(ctx.text('body'))
+  }),
   rest.delete('*/api/:apiVersion/channels/:channelId', (req, res, ctx) => {
     const channel = DiscordManager.channels[req.params.channelId]
     channel.deleted = true

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -6,9 +6,11 @@ process.env.CONVERT_KIT_API_SECRET = 'FAKE_CONVERT_KIT_API_SECRET'
 process.env.DISCORD_BOT_TOKEN = 'FAKE_BOT_TOKEN'
 process.env.GIST_REPO_THANKS = 'testThanks'
 
+beforeEach(() => jest.spyOn(Date, 'now'))
 beforeAll(() => server.listen({onUnhandledRequest: 'error'}))
 afterAll(() => server.close())
 afterEach(() => {
   server.resetHandlers()
   DiscordManager.cleanup()
+  jest.restoreAllMocks()
 })


### PR DESCRIPTION


**What**: As for requirement #24 I have added the extend command 


**Why**: Because it can useful to extend the default lifetime of the private-chat

**How**: To make this possible I have added the current lifetime in the topic.
The new command is only available in private chat. Example: `?private-chat extend 10`

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [X] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
