### PR TITLE
test: use fake timers instead of mocking date

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -3,7 +3,7 @@ const rollbar = require('./rollbar')
 
 const sleep = t =>
   new Promise(resolve =>
-    setTimeout(resolve, process.env.NODE_ENV === 'test' ? 0 : t),
+    process.env.NODE_ENV === 'test' ? resolve() : setTimeout(resolve, t),
   )
 
 const privateChannelPrefix =

--- a/tests/setup-env.js
+++ b/tests/setup-env.js
@@ -13,4 +13,5 @@ afterEach(() => {
   server.resetHandlers()
   DiscordManager.cleanup()
   jest.restoreAllMocks()
+  jest.useRealTimers()
 })


### PR DESCRIPTION

**What**: I have updated the implementation of `private-chat` tests

<!-- Why are these changes necessary? -->

**Why**: It's a better implementation

<!-- How were these changes implemented? -->

**How**: Replacing mocking date with fakeTimers 

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
