### PR TITLE
feat: add schedule stream command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3718,6 +3718,14 @@
         "tslib": "^1.9.0"
       }
     },
+    "chrono-node": {
+      "version": "2.1.11",
+      "resolved": "https://registry.npmjs.org/chrono-node/-/chrono-node-2.1.11.tgz",
+      "integrity": "sha512-hwCQZK+dcOVJAPBk2qIOIhlgG+ik89S241JeajkEGx+HxRKwo65yim22IOu8OSj13lJPc2wIazjzsOR/XsV1IQ==",
+      "requires": {
+        "dayjs": "^1.10.0"
+      }
+    },
     "ci-info": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ci-info/-/ci-info-2.0.0.tgz",
@@ -4369,6 +4377,11 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-2.16.1.tgz",
       "integrity": "sha512-sAJVKx/FqrLYHAQeN7VpJrPhagZc9R4ImZIWYRFZaaohR3KzmuK88touwsSwSVT8Qcbd4zoDsnGfX4GFB4imyQ==",
       "dev": true
+    },
+    "dayjs": {
+      "version": "1.10.3",
+      "resolved": "https://registry.npmjs.org/dayjs/-/dayjs-1.10.3.tgz",
+      "integrity": "sha512-/2fdLN987N8Ki7Id8BUN2nhuiRyxTLumQnSQf9CNncFCyqFsSKb9TNhzRYcC8K8eJSJOKvbvkImo/MKKhNi4iw=="
     },
     "debug": {
       "version": "2.6.9",

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "validate": "kcd-scripts validate"
   },
   "dependencies": {
+    "chrono-node": "^2.1.11",
     "discord.js": "12.3.1",
     "dotenv": "^8.2.0",
     "got": "^11.7.0",

--- a/src/commands/__tests__/index.js
+++ b/src/commands/__tests__/index.js
@@ -30,6 +30,7 @@ test('handles incoming messages', async () => {
     - clubs: Create a club with \`?clubs create LINK_TO_GOOGLE_FORM\` (learn more: <https://kcd.im/clubs>)
     - info: Gives information about the bot (deploy date etc.)
     - private-chat: Create a private channel with who you want. This channel is temporary.
-    - blog: Find articles on Kent's blog: <https://kentcdodds.com/blog>"
+    - blog: Find articles on Kent's blog: <https://kentcdodds.com/blog>
+    - schedule-stream: Enable users to schedule a stream"
   `)
 })

--- a/src/commands/command-fns/__tests__/help.js
+++ b/src/commands/command-fns/__tests__/help.js
@@ -25,7 +25,8 @@ test('prints help for all commands', async () => {
     - clubs: Create a club with \`?clubs create LINK_TO_GOOGLE_FORM\` (learn more: <https://kcd.im/clubs>)
     - info: Gives information about the bot (deploy date etc.)
     - private-chat: Create a private channel with who you want. This channel is temporary.
-    - blog: Find articles on Kent's blog: <https://kentcdodds.com/blog>"
+    - blog: Find articles on Kent's blog: <https://kentcdodds.com/blog>
+    - schedule-stream: Enable users to schedule a stream"
   `)
 })
 

--- a/src/commands/command-fns/__tests__/schedule-stream.js
+++ b/src/commands/command-fns/__tests__/schedule-stream.js
@@ -86,19 +86,16 @@ test('should give an error if the message contains an invalid time', async () =>
 
 test('should send a message to all users that reacted to the message and delete it then', async () => {
   jest.useFakeTimers('modern')
+  jest.setSystemTime(new Date(Date.UTC(2021, 0, 20, 14)))
 
   const {guild, kody, createMessage, getStreamerMessages} = await setup()
 
-  const eventTime = new Date()
-  eventTime.setMinutes(eventTime.getMinutes() + 30)
-
   await scheduleStream(
     createMessage(
-      `?schedule-stream "Migrating to Tailwind" on ${eventTime.toISOString()}`,
+      `?schedule-stream "Migrating to Tailwind" on January 20th from 3:00 PM - 8:00 PM UTC`,
       kody.user,
     ),
   )
-
   expect(getStreamerMessages()).toHaveLength(1)
   let dmMessage = ''
   server.use(
@@ -121,7 +118,7 @@ test('should send a message to all users that reacted to the message and delete 
   await cleanup(guild)
   expect(getStreamerMessages()).toHaveLength(1)
 
-  jest.advanceTimersByTime(1000 * 60 * 21)
+  jest.advanceTimersByTime(1000 * 60 * 70)
   await cleanup(guild)
   expect(getStreamerMessages()).toHaveLength(0)
   expect(dmMessage).toEqual(`Hey, <@${kody.id}> is going to stream!!`)

--- a/src/commands/command-fns/__tests__/schedule-stream.js
+++ b/src/commands/command-fns/__tests__/schedule-stream.js
@@ -174,7 +174,7 @@ test('should send a message to all users that reacted to the message and delete 
   expect(dmMessage).toEqual(`Hey, <@${kody.id}> is going to stream!!`)
 })
 
-test('should delete the scheduled stream if the streamer react to it', async () => {
+test('should delete the scheduled stream if the streamer react to it with ❌', async () => {
   const {guild, kody, createMessage, getStreamerMessages} = await setup(
     new Date(Date.UTC(2021, 0, 20, 14)),
   )

--- a/src/commands/command-fns/__tests__/schedule-stream.js
+++ b/src/commands/command-fns/__tests__/schedule-stream.js
@@ -92,11 +92,18 @@ test('should send a message to all users that reacted to the message and delete 
 
   await scheduleStream(
     createMessage(
+      `?schedule-stream "Migrating to Tailwind" on January 21th from 3:00 PM - 8:00 PM UTC`,
+      kody.user,
+    ),
+  )
+
+  await scheduleStream(
+    createMessage(
       `?schedule-stream "Migrating to Tailwind" on January 20th from 3:00 PM - 8:00 PM UTC`,
       kody.user,
     ),
   )
-  expect(getStreamerMessages()).toHaveLength(1)
+  expect(getStreamerMessages()).toHaveLength(2)
   let dmMessage = ''
   server.use(
     rest.get(
@@ -116,10 +123,13 @@ test('should send a message to all users that reacted to the message and delete 
 
   jest.advanceTimersByTime(1000 * 60 * 10)
   await cleanup(guild)
-  expect(getStreamerMessages()).toHaveLength(1)
+  expect(getStreamerMessages()).toHaveLength(2)
 
   jest.advanceTimersByTime(1000 * 60 * 70)
   await cleanup(guild)
-  expect(getStreamerMessages()).toHaveLength(0)
+  expect(getStreamerMessages()).toHaveLength(1)
+  expect(getStreamerMessages()[0].content).toContain(
+    'January 21th from 3:00 PM - 8:00 PM UTC',
+  )
   expect(dmMessage).toEqual(`Hey, <@${kody.id}> is going to stream!!`)
 })

--- a/src/commands/command-fns/__tests__/schedule-stream.js
+++ b/src/commands/command-fns/__tests__/schedule-stream.js
@@ -1,8 +1,11 @@
 const Discord = require('discord.js')
+const {rest} = require('msw')
 const {SnowflakeUtil} = require('discord.js')
 const {makeFakeClient} = require('test-utils')
+const {server} = require('server')
 const scheduleStream = require('../schedule-stream')
 const {getRole} = require('../../utils')
+const {cleanup} = require('../../../schedule-stream/cleanup')
 
 async function setup() {
   const {client, defaultChannels, kody, guild} = await makeFakeClient()
@@ -103,4 +106,53 @@ test('should give an error if the message contains an invalid time', async () =>
   expect(messages[0].content).toEqual(
     'The command is not valid. use `?schedule-stream help` to know more about the command.',
   )
+})
+
+test('should send a message to all users that reacted to the message and delete it then', async () => {
+  jest.useFakeTimers('modern')
+
+  const {
+    guild,
+    kody,
+    streamerRole,
+    createMessage,
+    getStreamerMessages,
+  } = await setup()
+
+  const eventTime = new Date()
+  eventTime.setMinutes(eventTime.getMinutes() + 30)
+  await kody.roles.add(streamerRole)
+  await scheduleStream(
+    createMessage(
+      `?schedule-stream "Migrating to Tailwind" on ${eventTime.toISOString()}`,
+      kody.user,
+    ),
+  )
+
+  expect(getStreamerMessages()).toHaveLength(1)
+  let dmMessage = ''
+  server.use(
+    rest.get(
+      '*/api/:apiVersion/channels/:channelId/messages/:messageId/reactions/:reaction',
+      (req, res, ctx) => {
+        return res(ctx.json([kody.user]))
+      },
+    ),
+    rest.post(
+      '*/api/:apiVersion/channels/:channelId/messages',
+      (req, res, ctx) => {
+        dmMessage = req.body.content
+        return res(ctx.status(201), ctx.json({}))
+      },
+    ),
+  )
+
+  jest.advanceTimersByTime(1000 * 60 * 10)
+  await cleanup(guild)
+  expect(getStreamerMessages()).toHaveLength(1)
+
+  jest.advanceTimersByTime(1000 * 60 * 21)
+  await cleanup(guild)
+  expect(getStreamerMessages()).toHaveLength(0)
+  expect(dmMessage).toEqual(`Hey, <@${kody.id}> is going to stream!!`)
 })

--- a/src/commands/command-fns/__tests__/schedule-stream.js
+++ b/src/commands/command-fns/__tests__/schedule-stream.js
@@ -1,0 +1,106 @@
+const Discord = require('discord.js')
+const {SnowflakeUtil} = require('discord.js')
+const {makeFakeClient} = require('test-utils')
+const scheduleStream = require('../schedule-stream')
+const {getRole} = require('../../utils')
+
+async function setup() {
+  const {client, defaultChannels, kody, guild} = await makeFakeClient()
+
+  const createMessage = (content, user) => {
+    return new Discord.Message(
+      client,
+      {
+        id: SnowflakeUtil.generate(),
+        content,
+        author: user,
+      },
+      defaultChannels.talkToBotsChannel,
+    )
+  }
+
+  const getBotMessages = () =>
+    Array.from(defaultChannels.talkToBotsChannel.messages.cache.values())
+  const getStreamerMessages = () =>
+    Array.from(defaultChannels.streamerChannel.messages.cache.values())
+
+  const streamerRole = getRole(guild, {name: 'Streamer'})
+
+  return {
+    guild,
+    getBotMessages,
+    getStreamerMessages,
+    kody,
+    botChannel: defaultChannels.talkToBotsChannel,
+    streamerChannel: defaultChannels.streamerChannel,
+    streamerRole,
+    createMessage,
+  }
+}
+
+test('should schedule a new stream', async () => {
+  const {kody, streamerRole, createMessage, getStreamerMessages} = await setup()
+
+  await kody.roles.add(streamerRole)
+  await scheduleStream(
+    createMessage(
+      `?schedule-stream "Migrating to Tailwind" on January 20th from 3:00 PM - 8:00 PM MDT`,
+      kody.user,
+    ),
+  )
+  const messages = getStreamerMessages()
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toEqual(
+    `📣 On January 20th from 3:00 PM - 8:00 PM MDT <@!${kody.id}> will be live streaming "Migrating to Tailwind". React with ✋ to be notified when the time arrives.`,
+  )
+})
+
+test('should show an error message when a general user tries to create a schedule', async () => {
+  const {getBotMessages, createMessage, kody} = await setup()
+
+  await scheduleStream(
+    createMessage(
+      `?schedule-stream "Migrating to Tailwind" on January 20th from 3:00 PM - 8:00 PM MDT`,
+      kody.user,
+    ),
+  )
+
+  const messages = getBotMessages()
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toEqual(
+    'Sorry but this command is only available for streamers.',
+  )
+})
+
+test('should give an error if the message is malformed', async () => {
+  const {getBotMessages, createMessage, kody, streamerRole} = await setup()
+
+  await kody.roles.add(streamerRole)
+  await scheduleStream(
+    createMessage(`?schedule-stream "Migrating to Tailwind"`, kody.user),
+  )
+
+  const messages = getBotMessages()
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toEqual(
+    'The command is not valid. use `?schedule-stream help` to know more about the command.',
+  )
+})
+
+test('should give an error if the message contains an invalid time', async () => {
+  const {kody, streamerRole, createMessage, getBotMessages} = await setup()
+
+  await kody.roles.add(streamerRole)
+  await scheduleStream(
+    createMessage(
+      `?schedule-stream "Migrating to Tailwind" on January 32th from 3:00 PM - 8:00 PM MDT`,
+      kody.user,
+    ),
+  )
+
+  const messages = getBotMessages()
+  expect(messages).toHaveLength(1)
+  expect(messages[0].content).toEqual(
+    'The command is not valid. use `?schedule-stream help` to know more about the command.',
+  )
+})

--- a/src/commands/command-fns/schedule-stream.js
+++ b/src/commands/command-fns/schedule-stream.js
@@ -3,10 +3,10 @@ const {
   getCommandArgs,
   getMember,
   getRole,
-  getChannel,
   commandPrefix,
   sendBotMessageReply,
 } = require('../utils')
+const {getStreamerChannel} = require('../../schedule-stream/utils')
 
 const invalidCommandMessage = `The command is not valid. use \`${commandPrefix}schedule-stream help\` to know more about the command.`
 
@@ -36,9 +36,7 @@ async function scheduleStream(message) {
     return sendBotMessageReply(message, invalidCommandMessage)
   }
 
-  const streamerChannel = getChannel(message.guild, {
-    name: '📅-stream-schedule',
-  })
+  const streamerChannel = getStreamerChannel(message.guild)
 
   const streamerMessage = await streamerChannel.send(
     `📣 On ${scheduleTime} ${member} will be live streaming "${subject}". React with ✋ to be notified when the time arrives.`,

--- a/src/commands/command-fns/schedule-stream.js
+++ b/src/commands/command-fns/schedule-stream.js
@@ -2,7 +2,6 @@ const chrono = require('chrono-node')
 const {
   getCommandArgs,
   getMember,
-  getRole,
   commandPrefix,
   sendBotMessageReply,
 } = require('../utils')
@@ -12,15 +11,8 @@ const invalidCommandMessage = `The command is not valid. use \`${commandPrefix}s
 
 async function scheduleStream(message) {
   const args = getCommandArgs(message.content)
-  const streamerRole = getRole(message.guild, {name: 'Streamer'})
   const member = getMember(message.guild, message.author.id)
 
-  if (!member.roles.cache.has(streamerRole.id)) {
-    return sendBotMessageReply(
-      message,
-      'Sorry but this command is only available for streamers.',
-    )
-  }
   const match = args.match(/^"(?<subject>.+)" on (?<scheduleTime>.+)$/i)
 
   if (!match) return sendBotMessageReply(message, invalidCommandMessage)

--- a/src/commands/command-fns/schedule-stream.js
+++ b/src/commands/command-fns/schedule-stream.js
@@ -4,6 +4,7 @@ const {
   getMember,
   commandPrefix,
   sendBotMessageReply,
+  getMessageLink,
 } = require('../utils')
 const {getStreamerChannel} = require('../../schedule-stream/utils')
 
@@ -41,6 +42,14 @@ async function scheduleStream(message) {
 
   const streamerMessage = await streamerChannel.send(
     `📣 On ${scheduleTime} ${member} will be live streaming "${subject}". React with ✋ to be notified when the time arrives.`,
+  )
+
+  await sendBotMessageReply(
+    message,
+    `
+Your stream has been scheduled: ${getMessageLink(streamerMessage)}.
+To cancel, react to that message with ❌. If you want to reschedule, then cancel the old one and schedule a new stream.
+`.trim(),
   )
 
   return streamerMessage.react('✋')

--- a/src/commands/command-fns/schedule-stream.js
+++ b/src/commands/command-fns/schedule-stream.js
@@ -23,6 +23,7 @@ async function scheduleStream(message) {
   if (
     parsedTime.length > 1 ||
     !parsedTime.length ||
+    //If the string is partially malformed chrono will parse only the valid string
     parsedTime[0].text !== scheduleTime
   ) {
     return sendBotMessageReply(message, invalidCommandMessage)

--- a/src/commands/command-fns/schedule-stream.js
+++ b/src/commands/command-fns/schedule-stream.js
@@ -1,0 +1,62 @@
+const chrono = require('chrono-node')
+const {
+  getCommandArgs,
+  getMember,
+  getRole,
+  getChannel,
+  commandPrefix,
+  sendBotMessageReply,
+} = require('../utils')
+
+const invalidCommandMessage = `The command is not valid. use \`${commandPrefix}schedule-stream help\` to know more about the command.`
+
+async function scheduleStream(message) {
+  const args = getCommandArgs(message.content)
+  const streamerRole = getRole(message.guild, {name: 'Streamer'})
+  const member = getMember(message.guild, message.author.id)
+
+  if (!member.roles.cache.has(streamerRole.id)) {
+    return sendBotMessageReply(
+      message,
+      'Sorry but this command is only available for streamers.',
+    )
+  }
+  const match = args.match(/^"(?<subject>.+)" on (?<scheduleTime>.+)$/i)
+
+  if (!match) return sendBotMessageReply(message, invalidCommandMessage)
+  const {subject, scheduleTime} = match.groups
+
+  const parsedTime = chrono.parse(scheduleTime)
+
+  if (
+    parsedTime.length > 1 ||
+    !parsedTime.length ||
+    parsedTime[0].text !== scheduleTime
+  ) {
+    return sendBotMessageReply(message, invalidCommandMessage)
+  }
+
+  const streamerChannel = getChannel(message.guild, {
+    name: '📅-stream-schedule',
+  })
+
+  const streamerMessage = await streamerChannel.send(
+    `📣 On ${scheduleTime} ${member} will be live streaming "${subject}". React with ✋ to be notified when the time arrives.`,
+  )
+
+  return streamerMessage.react('✋')
+}
+scheduleStream.description = 'Enable users to schedule a stream'
+scheduleStream.help = message =>
+  sendBotMessageReply(
+    message,
+    ` 
+This command, available only for streamers, gives the ability to schedule a new streaming: 
+
+Example:
+
+${commandPrefix}schedule-stream "Migrating to Tailwind" on January 20th from 3:00 PM - 8:00 PM MDT"
+    `.trim(),
+  )
+
+module.exports = scheduleStream

--- a/src/commands/command-fns/schedule-stream.js
+++ b/src/commands/command-fns/schedule-stream.js
@@ -12,6 +12,7 @@ const invalidCommandMessage = `The command is not valid. use \`${commandPrefix}s
 async function scheduleStream(message) {
   const args = getCommandArgs(message.content)
   const member = getMember(message.guild, message.author.id)
+  const now = new Date()
 
   const match = args.match(/^"(?<subject>.+)" on (?<scheduleTime>.+)$/i)
 
@@ -27,6 +28,13 @@ async function scheduleStream(message) {
     parsedTime[0].text !== scheduleTime
   ) {
     return sendBotMessageReply(message, invalidCommandMessage)
+  }
+
+  if (parsedTime[0].start.date() < now) {
+    return sendBotMessageReply(
+      message,
+      "The scheduled time can't be in the past",
+    )
   }
 
   const streamerChannel = getStreamerChannel(message.guild)

--- a/src/commands/command-fns/schedule-stream.js
+++ b/src/commands/command-fns/schedule-stream.js
@@ -50,7 +50,7 @@ scheduleStream.help = message =>
   sendBotMessageReply(
     message,
     ` 
-This command, available only for streamers, gives the ability to schedule a new streaming: 
+This command gives the ability to schedule a new streaming:
 
 Example:
 

--- a/src/commands/commands.js
+++ b/src/commands/commands.js
@@ -7,4 +7,5 @@ module.exports = {
   info: require('./command-fns/info'),
   'private-chat': require('./command-fns/private-chat'),
   blog: require('./command-fns/blog'),
+  'schedule-stream': require('./command-fns/schedule-stream'),
 }

--- a/src/index.js
+++ b/src/index.js
@@ -4,6 +4,7 @@ const admin = require('./admin')
 const clubApplication = require('./club-application')
 const privateChat = require('./private-chat')
 const rollbar = require('./rollbar')
+const scheduleStream = require('./schedule-stream')
 
 function setup(client) {
   onboarding.setup(client)
@@ -11,6 +12,7 @@ function setup(client) {
   admin.setup(client)
   clubApplication.setup(client)
   privateChat.setup(client)
+  scheduleStream.setup(client)
 }
 
 module.exports = {

--- a/src/schedule-stream/cleanup.js
+++ b/src/schedule-stream/cleanup.js
@@ -1,0 +1,63 @@
+const chrono = require('chrono-node')
+const {getStreamerChannel} = require('./utils')
+
+async function cleanup(guild) {
+  const streamerChannel = getStreamerChannel(guild)
+  const allMessages = Array.from(
+    (await streamerChannel.messages.fetch()).values(),
+  )
+
+  const now = new Date()
+
+  const parsedMessages = allMessages.reduce(
+    (acc, message) => {
+      const content = message.content
+      const match = content.match(/^📣 On (?<scheduleTime>.+) <.+$/i)
+      if (match) {
+        const parsedTime = chrono.parse(match.groups.scheduleTime)
+        if (
+          parsedTime.length > 1 ||
+          !parsedTime.length ||
+          parsedTime[0].text !== match.groups.scheduleTime
+        ) {
+          acc.invalidMessages.push(message)
+        } else if (parsedTime[0].start.date() <= now) {
+          acc.streamingToNotify.push(message)
+        }
+      } else {
+        acc.invalidMessages.push(message)
+      }
+      return acc
+    },
+    {
+      invalidMessages: [],
+      streamingToNotify: [],
+    },
+  )
+
+  const promises = parsedMessages.invalidMessages.map(message =>
+    message.delete(),
+  )
+  for (const message of parsedMessages.streamingToNotify) {
+    const reactionMessage = message.reactions.cache.find(
+      ({emoji}) => emoji.name === '✋',
+    )
+    if (reactionMessage) {
+      // eslint-disable-next-line no-await-in-loop
+      const notificationUsers = (await reactionMessage.users.fetch()).filter(
+        user => !user.bot,
+      )
+      const streamerUser = Array.from(message.mentions.users.values())[0]
+      notificationUsers.forEach(user => {
+        promises.push(user.send(`Hey, ${streamerUser} is going to stream!!`))
+      })
+    }
+    promises.push(message.delete())
+  }
+
+  await Promise.all(promises)
+}
+
+module.exports = {
+  cleanup,
+}

--- a/src/schedule-stream/cleanup.js
+++ b/src/schedule-stream/cleanup.js
@@ -1,10 +1,42 @@
 const chrono = require('chrono-node')
 const {getStreamerChannel} = require('./utils')
 
+function getStreamer(message) {
+  // if someone has been tagged into the subject the first mention is always the streamer
+  return Array.from(message.mentions.users.values())[0]
+}
+
+async function filterNotDeletedMessages(messages) {
+  const deletePromises = []
+  const filteredMessages = []
+  for (const message of messages) {
+    const streamerUser = getStreamer(message)
+    const deleteMessageReaction = message.reactions.cache.find(
+      ({emoji}) => emoji.name === '❌',
+    )
+    let shouldDeleteTheMessage = false
+    if (deleteMessageReaction) {
+      shouldDeleteTheMessage =
+        Array.from(
+          // eslint-disable-next-line no-await-in-loop
+          (await deleteMessageReaction.users.fetch()).values(),
+        ).findIndex(user => user.id === streamerUser.id) >= 0
+      if (shouldDeleteTheMessage) {
+        deletePromises.push(message.delete())
+      }
+    }
+    if (!shouldDeleteTheMessage) {
+      filteredMessages.push(message)
+    }
+  }
+  await Promise.all(deletePromises)
+  return filteredMessages
+}
+
 async function cleanup(guild) {
   const streamerChannel = getStreamerChannel(guild)
-  const allMessages = Array.from(
-    (await streamerChannel.messages.fetch()).values(),
+  const allMessages = await filterNotDeletedMessages(
+    Array.from((await streamerChannel.messages.fetch()).values()),
   )
 
   const now = new Date()
@@ -39,15 +71,15 @@ async function cleanup(guild) {
     message.delete(),
   )
   for (const message of parsedMessages.streamingToNotify) {
-    const reactionMessage = message.reactions.cache.find(
+    const streamerUser = getStreamer(message)
+    const notificationReactionMessage = message.reactions.cache.find(
       ({emoji}) => emoji.name === '✋',
     )
-    if (reactionMessage) {
-      // eslint-disable-next-line no-await-in-loop
-      const notificationUsers = (await reactionMessage.users.fetch()).filter(
-        user => !user.bot,
-      )
-      const streamerUser = Array.from(message.mentions.users.values())[0]
+    if (notificationReactionMessage) {
+      const notificationUsers = ( // eslint-disable-next-line no-await-in-loop
+        await notificationReactionMessage.users.fetch()
+      ).filter(user => !user.bot)
+
       notificationUsers.forEach(user => {
         promises.push(user.send(`Hey, ${streamerUser} is going to stream!!`))
       })

--- a/src/schedule-stream/index.js
+++ b/src/schedule-stream/index.js
@@ -1,0 +1,10 @@
+const {cleanupGuildOnInterval} = require('../utils')
+const scheduleStream = {
+  ...require('./cleanup'),
+}
+
+function setup(client) {
+  cleanupGuildOnInterval(client, guild => scheduleStream.cleanup(guild), 5000)
+}
+
+module.exports = {...scheduleStream, setup}

--- a/src/schedule-stream/utils.js
+++ b/src/schedule-stream/utils.js
@@ -1,7 +1,7 @@
 const {getChannel} = require('../utils')
 
 function getStreamerChannel(guild) {
-  return getChannel(guild, {name: '📅-stream-schedule'})
+  return getChannel(guild, {name: '⏱-upcoming-streams'})
 }
 
 module.exports = {

--- a/src/schedule-stream/utils.js
+++ b/src/schedule-stream/utils.js
@@ -1,7 +1,7 @@
 const {getChannel} = require('../utils')
 
 function getStreamerChannel(guild) {
-  return getChannel(guild, {name: '⏱-upcoming-streams'})
+  return getChannel(guild, {name: 'upcoming-streams'})
 }
 
 module.exports = {

--- a/src/schedule-stream/utils.js
+++ b/src/schedule-stream/utils.js
@@ -1,0 +1,9 @@
+const {getChannel} = require('../utils')
+
+function getStreamerChannel(guild) {
+  return getChannel(guild, {name: '📅-stream-schedule'})
+}
+
+module.exports = {
+  getStreamerChannel,
+}

--- a/src/utils.js
+++ b/src/utils.js
@@ -54,7 +54,7 @@ function getChannel(guild, {name, type = 'text'}) {
 }
 
 /**
- * The name will be lowercased and the first channel with a lowercased name that
+ * The name will be lowercased and the first role with a lowercased name that
  * equals it will be returned.
  * @param {*} guild the guild to find the role in
  * @param {{name: string}} searchOptions

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -70,7 +70,7 @@ async function createChannels(client, guild) {
   const thanksChannel = await guild.channels.create(`😍-thank-you`)
   guild.channels.cache.set(thanksChannel.id, thanksChannel)
 
-  const streamerChannel = await guild.channels.create(`📅-stream-schedule`)
+  const streamerChannel = await guild.channels.create(`⏱-upcoming-streams`)
   guild.channels.cache.set(streamerChannel.id, streamerChannel)
 
   return {

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -131,13 +131,6 @@ function createRoles(client, guild) {
   )
   guild.roles.cache.set(newConfirmedMemberRole.id, newConfirmedMemberRole)
 
-  const streamerRole = new Discord.Role(
-    client,
-    {id: SnowflakeUtil.generate(), name: 'Streamer'},
-    guild,
-  )
-  guild.roles.cache.set(streamerRole.id, streamerRole)
-
   return {
     memberRole,
     unconfirmedRole,

--- a/tests/test-utils.js
+++ b/tests/test-utils.js
@@ -70,6 +70,9 @@ async function createChannels(client, guild) {
   const thanksChannel = await guild.channels.create(`😍-thank-you`)
   guild.channels.cache.set(thanksChannel.id, thanksChannel)
 
+  const streamerChannel = await guild.channels.create(`📅-stream-schedule`)
+  guild.channels.cache.set(streamerChannel.id, streamerChannel)
+
   return {
     kentLiveChannel,
     kentLiveVoiceChannel,
@@ -81,6 +84,7 @@ async function createChannels(client, guild) {
     privateChatCategory,
     talkToBotsChannel,
     thanksChannel,
+    streamerChannel,
   }
 }
 
@@ -126,6 +130,13 @@ function createRoles(client, guild) {
     guild,
   )
   guild.roles.cache.set(newConfirmedMemberRole.id, newConfirmedMemberRole)
+
+  const streamerRole = new Discord.Role(
+    client,
+    {id: SnowflakeUtil.generate(), name: 'Streamer'},
+    guild,
+  )
+  guild.roles.cache.set(streamerRole.id, streamerRole)
 
   return {
     memberRole,


### PR DESCRIPTION
close #45 
**What**: I have added a new command `?schedule-stream` as described in the issue
 

**Why**: There are some users in discord that want to stream sometime. With this new command, they could schedule their streaming 

**How**: This command requires:

1. A channel called `⏱-upcoming-streams`

<!-- Have you done all of these things?  -->

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation
- [X] Tests
- [ ] Ready to be merged
      <!-- In your opinion, is this ready to be merged as soon as it's reviewed? -->

<!-- feel free to add additional comments -->
