### PR TITLE
fix: allow multiple spaces when parsing command

### DIFF
--- a/src/utils.js
+++ b/src/utils.js
@@ -80,8 +80,8 @@ function getCategory(guild, {name}) {
   )
 }
 
-const prodRegex = /^\?(?<command>\S+?)($| )(?<args>(.|\n)*)/
-const devRegex = /^~(?<command>\S+?)($| )(?<args>(.|\n)*)/
+const prodRegex = /^\?(?<command>\S+?)($| +)(?<args>(.|\n)*)/
+const devRegex = /^~(?<command>\S+?)($| +)(?<args>(.|\n)*)/
 const commandPrefix =
   process.env.NODE_ENV === 'production' || process.env.NODE_ENV === 'test'
     ? '?'


### PR DESCRIPTION
**What**: the bot can be less strict about number of spaces that separate command from arguments

**Why**: https://discord.com/channels/715220730605731931/801954790077890601/813841453724991568

**How**: update regex

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests
- [x] Ready to be merged

Ready to merge assumes the existing unit tests will pass in CI.

I noticed the problem reported on Discord and it seems to have a simple solution, but I am exhausted after my day job to write new regression tests right now => please let me know if you want me to write some tests before (or after) merging, I can do that some other day.