### PR TITLE
Updates all mentions of 'master' in documentation to 'main'

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -11,20 +11,20 @@ series [How to Contribute to an Open Source Project on GitHub][egghead]
 2. Run `npm run setup -s` to install dependencies and run validation
 3. Create a branch for your PR with `git checkout -b pr/your-branch-name`
 
-> Tip: Keep your `master` branch pointing at the original repository and make
-> pull requests from branches on your fork. To do this, run:
+> Tip: Keep your `main` branch pointing at the original repository and make pull
+> requests from branches on your fork. To do this, run:
 >
 > ```
 > git remote add upstream https://github.com/kentcdodds/kcd-discord-bot
 > git fetch upstream
-> git branch --set-upstream-to=upstream/master master
+> git branch --set-upstream-to=upstream/main main
 > ```
 >
 > This will add the original repository as a "remote" called "upstream," Then
-> fetch the git information from that remote, then set your local `master`
-> branch to use the upstream master branch whenever you run `git pull`. Then you
-> can make all of your pull request branches based on this `master` branch.
-> Whenever you want to update your version of `master`, do a regular `git pull`.
+> fetch the git information from that remote, then set your local `main` branch
+> to use the upstream main branch whenever you run `git pull`. Then you can make
+> all of your pull request branches based on this `main` branch. Whenever you
+> want to update your version of `main`, do a regular `git pull`.
 
 ## Committing and Pushing changes
 

--- a/README.md
+++ b/README.md
@@ -32,7 +32,6 @@ To get a list of commands, run: `?help` in
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Installation](#installation)
 - [Usage](#usage)
 - [Issues](#issues)
   - [🐛 Bugs](#-bugs)
@@ -108,7 +107,7 @@ MIT
 [prs-badge]: https://img.shields.io/badge/PRs-welcome-brightgreen.svg?style=flat-square
 [prs]: http://makeapullrequest.com
 [coc-badge]: https://img.shields.io/badge/code%20of-conduct-ff69b4.svg?style=flat-square
-[coc]: https://github.com/kentcdodds/kcd-discord-bot/blob/master/other/CODE_OF_CONDUCT.md
+[coc]: https://github.com/kentcdodds/kcd-discord-bot/blob/main/other/CODE_OF_CONDUCT.md
 [emojis]: https://github.com/all-contributors/all-contributors#emoji-key
 [all-contributors]: https://github.com/all-contributors/all-contributors
 [all-contributors-badge]: https://img.shields.io/github/all-contributors/kentcdodds/kcd-discord-bot?color=orange&style=flat-square

--- a/other/MAINTAINING.md
+++ b/other/MAINTAINING.md
@@ -48,7 +48,7 @@ to release. See the next section on Releases for more about that.
 
 ## Release
 
-Our releases are automatic. They happen whenever code lands into `master`. A
+Our releases are automatic. They happen whenever code lands into `main`. A
 travis build gets kicked off and if it's successful, a tool called
 [`semantic-release`](https://github.com/semantic-release/semantic-release) is
 used to automatically publish a new release to npm as well as a changelog to


### PR DESCRIPTION
**What**: Update all mentions of 'master' in documentation to 'main'. Resolves https://github.com/kentcdodds/kcd-discord-bot/issues/56

**Why**: This repo uses 'main' as the primary branch. The documentation should reflect that. 

**How**: Just a find and replace 😅 

**Checklist**:
- [x] Documentation
- [N/A] Tests
- [x] Ready to be merged

This is my first ever open source PR ❤️ 