### PR TITLE
Thanks gratitude rank

### DIFF
--- a/src/commands/command-fns/__tests__/thanks.ts
+++ b/src/commands/command-fns/__tests__/thanks.ts
@@ -354,7 +354,33 @@ test('should show the rank of the top 10 users', async () => {
   `)
 })
 
-test.todo('should show the gratitude rank of the user message')
+test('should show a message if the user has never thanked', async () => {
+  server.use(
+    rest.get(
+      `https://api.github.com/gists/${process.env.GIST_REPO_THANKS}`,
+      (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({files: {'thanks.json': {content: ''}}}),
+        )
+      },
+    ),
+  )
+  const {getBotMessages, getThanksMessages, message} = await setup(
+    '?thanks gratitude rank',
+  )
+
+  await thanks(message)
+
+  expect(getBotMessages()).toHaveLength(1)
+  expect(getThanksMessages()).toHaveLength(0)
+  expect(getBotMessages()[0]?.content).toMatchInlineSnapshot(`
+    This is the rank of the requested member:
+    - kody hasn't thanked anyone yet 🙁
+  `)
+})
+
+test.todo('should show the gratitude rank of the user')
 test.todo('should show the gratitude rank of the mentioned user')
 test.todo('should show the gratitude rank of the top 10 users')
 

--- a/src/commands/command-fns/__tests__/thanks.ts
+++ b/src/commands/command-fns/__tests__/thanks.ts
@@ -380,7 +380,39 @@ test('should show a message if the user has never thanked', async () => {
   `)
 })
 
-test.todo('should show the gratitude rank of the user')
+test('should show the gratitude rank of the user', async () => {
+  const {getBotMessages, getThanksMessages, message, kody} = await setup(
+    '?thanks gratitude rank',
+  )
+
+  const thanksHistory: ThanksHistory = [
+    ['someone else', kody.id, 'link_to_message'],
+  ]
+
+  server.use(
+    rest.get(
+      `https://api.github.com/gists/${process.env.GIST_REPO_THANKS}`,
+      (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            files: {'thanks.json': {content: JSON.stringify(thanksHistory)}},
+          }),
+        )
+      },
+    ),
+  )
+
+  await thanks(message)
+
+  expect(getBotMessages()).toHaveLength(1)
+  expect(getThanksMessages()).toHaveLength(0)
+  expect(getBotMessages()[0]?.content).toMatchInlineSnapshot(`
+    This is the rank of the requested member:
+    - kody has thanked other people 1 time 👏
+  `)
+})
+
 test.todo('should show the gratitude rank of the mentioned user')
 test.todo('should show the gratitude rank of the top 10 users')
 

--- a/src/commands/command-fns/__tests__/thanks.ts
+++ b/src/commands/command-fns/__tests__/thanks.ts
@@ -339,6 +339,10 @@ test('should show the rank of the top 10 users', async () => {
   `)
 })
 
+test.todo('should show the gratitude rank of the user message')
+test.todo('should show the gratitude rank of the mentioned user')
+test.todo('should show the gratitude rank of the top 10 users')
+
 test('should give an error if there are some issues retrieving data from gist', async () => {
   server.use(
     rest.get(

--- a/src/commands/command-fns/__tests__/thanks.ts
+++ b/src/commands/command-fns/__tests__/thanks.ts
@@ -195,7 +195,7 @@ test('should say thanks if there is no message', async () => {
     .toMatchInlineSnapshot(`
     Hey <@!123>! You got thanked! 🎉
 
-    <@123> appreciated you.
+    <@!123> appreciated you.
 
     Link: <https://discordapp.com/channels/123/123/123>
   `)

--- a/src/commands/command-fns/__tests__/thanks.ts
+++ b/src/commands/command-fns/__tests__/thanks.ts
@@ -93,9 +93,9 @@ test('should say thanks if the message is complete', async () => {
   assert(user1)
 
   const thanksMessageLink = `https://discordapp.com/channels/${botChannel.guild.id}/${botChannel.id}/${message.id}`
-  const thanksHistory: ThanksHistory = [
-    [user1.id, kody.user.id, thanksMessageLink],
-  ]
+  const thanksHistory: ThanksHistory = {
+    [thanksMessageLink]: {thanker: kody.user.id, thanked: [user1.id]},
+  }
   expect(thanksRetrieved).toBeTruthy()
 
   // @ts-expect-error no idea how to deal with this situation...
@@ -232,9 +232,9 @@ test('should show the rank of the user message', async () => {
     '?thanks rank',
   )
 
-  const thanksHistory: ThanksHistory = [
-    [kody.id, 'senderId', 'link_to_message'],
-  ]
+  const thanksHistory: ThanksHistory = {
+    mockMessageId: {thanker: 'mockThanker', thanked: [kody.id]},
+  }
 
   server.use(
     rest.get(
@@ -271,10 +271,10 @@ test('should show the rank of the mentioned user', async () => {
 
   const [user1] = mentionedUsers
   assert(user1)
-  const thanksHistory: ThanksHistory = [
-    [user1.id, kody.id, 'link_to_message1'],
-    [user1.id, kody.id, 'link_to_message2'],
-  ]
+  const thanksHistory: ThanksHistory = {
+    link_to_message1: {thanker: kody.id, thanked: [user1.id]},
+    link_to_message2: {thanker: kody.id, thanked: [user1.id]},
+  }
 
   server.use(
     rest.get(
@@ -312,13 +312,16 @@ test('should show the rank of the top 10 users', async () => {
     Array.from(Array(20).keys()).map(index => createUser(`user${index}`)),
   )
 
-  const thanksHistory: ThanksHistory = []
+  const thanksHistory: ThanksHistory = {}
   rankedUsers.forEach((rankedUser, index) => {
     Array<string>(index)
       .fill('link_to_message')
-      .forEach(mockThankMessage =>
-        thanksHistory.push([rankedUser.id, kody.id, mockThankMessage]),
-      )
+      .forEach((_, i) => {
+        thanksHistory[`mockMessageId${index}+${i}`] = {
+          thanker: kody.id,
+          thanked: [rankedUser.id],
+        }
+      })
   })
 
   server.use(
@@ -385,9 +388,9 @@ test('should show the gratitude rank of the user', async () => {
     '?thanks gratitude rank',
   )
 
-  const thanksHistory: ThanksHistory = [
-    ['someone else', kody.id, 'link_to_message'],
-  ]
+  const thanksHistory: ThanksHistory = {
+    link_to_message: {thanker: kody.id, thanked: ['someone else']},
+  }
 
   server.use(
     rest.get(
@@ -424,10 +427,11 @@ test('should show the gratitude rank of the mentioned user', async () => {
 
   const [user1] = mentionedUsers
   assert(user1)
-  const thanksHistory: ThanksHistory = [
-    [kody.id, user1.id, 'link_to_message1'],
-    [kody.id, user1.id, 'link_to_message2'],
-  ]
+
+  const thanksHistory: ThanksHistory = {
+    link_to_message1: {thanker: user1.id, thanked: [kody.id]},
+    link_to_message2: {thanker: user1.id, thanked: [kody.id]},
+  }
 
   server.use(
     rest.get(
@@ -465,13 +469,16 @@ test('should show the gratitude rank of the top 10 users', async () => {
     Array.from(Array(20).keys()).map(index => createUser(`user${index}`)),
   )
 
-  const thanksHistory: ThanksHistory = []
+  const thanksHistory: ThanksHistory = {}
   rankedUsers.forEach((rankedUser, index) => {
     Array<string>(index)
       .fill('link_to_message')
-      .forEach(mockThankMessage =>
-        thanksHistory.push([kody.id, rankedUser.id, mockThankMessage]),
-      )
+      .forEach((_, i) => {
+        thanksHistory[`mockMessageId${index}+${i}`] = {
+          thanker: rankedUser.id,
+          thanked: [kody.id],
+        }
+      })
   })
 
   server.use(

--- a/src/commands/command-fns/__tests__/thanks.ts
+++ b/src/commands/command-fns/__tests__/thanks.ts
@@ -413,7 +413,46 @@ test('should show the gratitude rank of the user', async () => {
   `)
 })
 
-test.todo('should show the gratitude rank of the mentioned user')
+test('should show the gratitude rank of the mentioned user', async () => {
+  const {
+    getBotMessages,
+    getThanksMessages,
+    kody,
+    message,
+    mentionedUsers,
+  } = await setup('?thanks gratitude rank', ['user1'])
+
+  const [user1] = mentionedUsers
+  assert(user1)
+  const thanksHistory: ThanksHistory = [
+    [kody.id, user1.id, 'link_to_message1'],
+    [kody.id, user1.id, 'link_to_message2'],
+  ]
+
+  server.use(
+    rest.get(
+      `https://api.github.com/gists/${process.env.GIST_REPO_THANKS}`,
+      (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            files: {'thanks.json': {content: JSON.stringify(thanksHistory)}},
+          }),
+        )
+      },
+    ),
+  )
+
+  await thanks(message)
+
+  expect(getBotMessages()).toHaveLength(1)
+  expect(getThanksMessages()).toHaveLength(0)
+  expect(getBotMessages()[0]?.content).toMatchInlineSnapshot(`
+    This is the rank of the requested member:
+    - user1 has thanked other people 2 times 👏
+  `)
+})
+
 test.todo('should show the gratitude rank of the top 10 users')
 
 test('should give an error if there are some issues retrieving data from gist', async () => {

--- a/src/commands/command-fns/__tests__/thanks.ts
+++ b/src/commands/command-fns/__tests__/thanks.ts
@@ -302,9 +302,7 @@ test('should show the rank of the top 10 users', async () => {
 
   const ranks: ThanksHistory = {}
   rankedUsers.forEach((rankedUser, index) => {
-    ranks[rankedUser.id] = Array.from(Array(index).keys()).map(
-      messageIndex => `link_to_message${messageIndex}`,
-    )
+    ranks[rankedUser.id] = Array(index).fill('link_to_message')
   })
 
   server.use(

--- a/src/commands/command-fns/__tests__/thanks.ts
+++ b/src/commands/command-fns/__tests__/thanks.ts
@@ -453,7 +453,59 @@ test('should show the gratitude rank of the mentioned user', async () => {
   `)
 })
 
-test.todo('should show the gratitude rank of the top 10 users')
+test('should show the gratitude rank of the top 10 users', async () => {
+  const {
+    getBotMessages,
+    getThanksMessages,
+    kody,
+    message,
+    createUser,
+  } = await setup('?thanks gratitude rank top')
+  const rankedUsers = await Promise.all(
+    Array.from(Array(20).keys()).map(index => createUser(`user${index}`)),
+  )
+
+  const thanksHistory: ThanksHistory = []
+  rankedUsers.forEach((rankedUser, index) => {
+    Array<string>(index)
+      .fill('link_to_message')
+      .forEach(mockThankMessage =>
+        thanksHistory.push([kody.id, rankedUser.id, mockThankMessage]),
+      )
+  })
+
+  server.use(
+    rest.get(
+      `https://api.github.com/gists/${process.env.GIST_REPO_THANKS}`,
+      (req, res, ctx) => {
+        return res(
+          ctx.status(200),
+          ctx.json({
+            files: {'thanks.json': {content: JSON.stringify(thanksHistory)}},
+          }),
+        )
+      },
+    ),
+  )
+
+  await thanks(message)
+
+  expect(getBotMessages()).toHaveLength(1)
+  expect(getThanksMessages()).toHaveLength(0)
+  expect(getBotMessages()[0]?.content).toMatchInlineSnapshot(`
+    This is the list of the most grateful members 💪:
+    - user19 has thanked other people 19 times 👏
+    - user18 has thanked other people 18 times 👏
+    - user17 has thanked other people 17 times 👏
+    - user16 has thanked other people 16 times 👏
+    - user15 has thanked other people 15 times 👏
+    - user14 has thanked other people 14 times 👏
+    - user13 has thanked other people 13 times 👏
+    - user12 has thanked other people 12 times 👏
+    - user11 has thanked other people 11 times 👏
+    - user10 has thanked other people 10 times 👏
+  `)
+})
 
 test('should give an error if there are some issues retrieving data from gist', async () => {
   server.use(

--- a/src/commands/command-fns/thanks.ts
+++ b/src/commands/command-fns/thanks.ts
@@ -147,7 +147,7 @@ async function thanks(message: TDiscord.Message) {
     )
   }
 
-  function listThanks(users: Array<TDiscord.User>) {
+  function listUsersByThanksReceived(users: Array<TDiscord.User>) {
     return users
       .map(usr => {
         return {
@@ -162,6 +162,24 @@ async function thanks(message: TDiscord.Message) {
         return count > 0
           ? `- ${username} has been thanked ${count} ${times} 👏`
           : `- ${username} hasn't been thanked yet 🙁`
+      })
+      .join('\n')
+  }
+
+  function listUsersByThanksSent(users: Array<TDiscord.User>) {
+    return users
+      .map(usr => {
+        return {
+          username: usr.username,
+          count: thanksHistory.filter(([, sender]) => sender === usr.id).length,
+        }
+      })
+      .sort((a, z) => z.count - a.count)
+      .map(({username, count}) => {
+        const times = `time${count === 1 ? '' : 's'}`
+        return count > 0
+          ? `- ${username} has thanked other people ${count} ${times} 👏`
+          : `- ${username} hasn't thanked anyone yet 🙁`
       })
       .join('\n')
   }
@@ -188,7 +206,7 @@ async function thanks(message: TDiscord.Message) {
     return message.channel.send(
       `
 This is the list of the top thanked members 💪:
-${listThanks(topUsers)}
+${listUsersByThanksReceived(topUsers)}
       `.trim(),
     )
   } else if (rankArgumentList.length === 1 && rankArgumentList[0] === 'rank') {
@@ -204,7 +222,7 @@ ${listThanks(topUsers)}
     return message.channel.send(
       `
 This is the rank of the requested ${members}:
-${listThanks(searchedMembers)}
+${listUsersByThanksReceived(searchedMembers)}
       `.trim(),
     )
   } else if (
@@ -224,8 +242,8 @@ ${listThanks(searchedMembers)}
     return message.channel.send(
       `
 This is the rank of the requested ${members}:
-- kody hasn't thanked anyone yet 🙁
-`.trim(),
+${listUsersByThanksSent(searchedMembers)}
+      `.trim(),
     )
   } else {
     return sayThankYou(args, message, thanksHistory)

--- a/src/commands/command-fns/thanks.ts
+++ b/src/commands/command-fns/thanks.ts
@@ -207,6 +207,26 @@ This is the rank of the requested ${members}:
 ${listThanks(searchedMembers)}
       `.trim(),
     )
+  } else if (
+    rankArgumentList.length === 2 &&
+    rankArgumentList[0] === 'gratitude' &&
+    rankArgumentList[1] === 'rank'
+  ) {
+    const mentionedMembers = Array.from(
+      message.mentions.members?.values() ?? {length: 0},
+    )
+    let searchedMembers = [message.author]
+    if (mentionedMembers.length > 0) {
+      searchedMembers = mentionedMembers.map(member => member.user)
+    }
+
+    const members = `member${searchedMembers.length === 1 ? '' : 's'}`
+    return message.channel.send(
+      `
+This is the rank of the requested ${members}:
+- kody hasn't thanked anyone yet 🙁
+`.trim(),
+    )
   } else {
     return sayThankYou(args, message, thanksHistory)
   }

--- a/src/commands/command-fns/thanks.ts
+++ b/src/commands/command-fns/thanks.ts
@@ -213,8 +213,11 @@ thanks.help = async (message: TDiscord.Message) => {
   const commandsList = [
     `- Send \`?thanks @UserName for answering my question about which socks I should wear and being so polite.\` (for example), and your thanks will appear in the ${thanksChannel}.`,
     `- Send \`?thanks rank\` to show the number of times you have been thanked.`,
-    `- Send \`?thanks rank top\` to show the top 10 users.`,
-    `- Send \`?thanks rank @Username\` to show the number of times have been thanked the mentioned users.`,
+    `- Send \`?thanks rank top\` to show the top 10 most thanked users.`,
+    `- Send \`?thanks rank @Username\` to show the number of times @Username has been thanked.`,
+    `- Send \`?thanks gratitude rank\` to show the number of times you have thanked someone else.`,
+    `- Send \`?thanks gratitude top\` to show the top 10 users who have thanked others the most times.`,
+    `- Send \`?thanks gratitude @UserName\` to show the number of times @Username has thanked someone else.`,
   ]
   await message.channel.send(
     `

--- a/src/commands/command-fns/thanks.ts
+++ b/src/commands/command-fns/thanks.ts
@@ -148,9 +148,7 @@ async function thanks(message: TDiscord.Message) {
           count: thanksHistory[usr.id]?.length ?? 0,
         }
       })
-      .sort((a, z) => {
-        return a.count === z.count ? 0 : z.count > a.count ? 1 : -1
-      })
+      .sort((a, z) => z.count - a.count)
       .map(({username, count}) => {
         const times = `time${count === 1 ? '' : 's'}`
         return count > 0

--- a/src/commands/command-fns/thanks.ts
+++ b/src/commands/command-fns/thanks.ts
@@ -284,8 +284,8 @@ thanks.help = async (message: TDiscord.Message) => {
     `- Send \`?thanks rank top\` to show the top 10 most thanked users.`,
     `- Send \`?thanks rank @Username\` to show the number of times @Username has been thanked.`,
     `- Send \`?thanks gratitude rank\` to show the number of times you have thanked someone else.`,
-    `- Send \`?thanks gratitude top\` to show the top 10 users who have thanked others the most times.`,
-    `- Send \`?thanks gratitude @UserName\` to show the number of times @Username has thanked someone else.`,
+    `- Send \`?thanks gratitude rank top\` to show the top 10 users who have thanked others the most times.`,
+    `- Send \`?thanks gratitude rank @UserName\` to show the number of times @Username has thanked someone else.`,
   ]
   await message.channel.send(
     `

--- a/src/commands/command-fns/thanks.ts
+++ b/src/commands/command-fns/thanks.ts
@@ -119,7 +119,7 @@ Link: <${messageLink}>`
     : `
 Hey ${thankedMembersList}! You got thanked! 🎉
 
-${member.user} appreciated you.
+${member} appreciated you.
 
 Link: <${messageLink}>`
 


### PR DESCRIPTION
**What**:
Resolves issue: https://github.com/kentcdodds/kcd-discord-bot/issues/34
In particular adds the following commands:
```
?thanks gratitude rank
?thanks gratitude rank top
?thanks gratitude rank @Username
```

Each operate just like their non-gratitude equivalents but score people based on thanks sent rather than received.

**Why**:
Just a nice way to see who is the most grateful :-)

**How**:
Required a restructuring of the existing ThankHistory datastructure, which did not previously retain any information about who had been the 'thanker' for each thank action. 

**Checklist**:
- [x] Documentation
- [x] Tests
- [ ] Ready to be merged
⚠️ If merged right away, would conflict with existing thank history data ⚠️
It is ready to be merged if and only if the existing thank history data were to be reset