### PR TITLE
Bot messages: Fixed a typo and improvement suggestion

### DIFF
--- a/src/reactions/__tests__/index.ts
+++ b/src/reactions/__tests__/index.ts
@@ -56,7 +56,7 @@ test('botofficehours sends the message author the office-hours reply', async () 
   })
 
   expect(generalChannel.lastMessage?.content).toMatchInlineSnapshot(
-    `<@!kody>, If you don't get a satisfactory answer here, then you can feel free to ask Kent during his <https://kcd.im/office-hours> in <#🏫-kcd-office-hours>. To do so, formulate your question to make sure it's clear (follow the guildelines in <https://kcd.im/ask>) and a <https://kcd.im/repro> helps a lot if applicable. Then post it to <#🏫-kcd-office-hours> or join the meeting and ask live. Kent streams/records his office hours on YouTube so even if you can't make it in person, you should be able to watch his answer later.`,
+    `<@!kody>, If you don't get a satisfactory answer here, feel free to ask Kent during his <https://kcd.im/office-hours> in <#🏫-kcd-office-hours>. To do so, formulate your question to make sure it's clear (follow the guidelines in <https://kcd.im/ask>) and a <https://kcd.im/repro> helps a lot if applicable. Then post it to <#🏫-kcd-office-hours> or join the meeting and ask live. Kent streams/records his office hours on YouTube so even if you can't make it in person, you should be able to watch his answer later.`,
   )
 })
 

--- a/src/reactions/reactions.ts
+++ b/src/reactions/reactions.ts
@@ -36,7 +36,7 @@ async function officeHours(messageReaction: TDiscord.MessageReaction) {
   if (!officeHoursChannel) return
 
   await message.reply(
-    `If you don't get a satisfactory answer here, then you can feel free to ask Kent during his <https://kcd.im/office-hours> in ${officeHoursChannel}. To do so, formulate your question to make sure it's clear (follow the guildelines in <https://kcd.im/ask>) and a <https://kcd.im/repro> helps a lot if applicable. Then post it to ${officeHoursChannel} or join the meeting and ask live. Kent streams/records his office hours on YouTube so even if you can't make it in person, you should be able to watch his answer later.`,
+    `If you don't get a satisfactory answer here, feel free to ask Kent during his <https://kcd.im/office-hours> in ${officeHoursChannel}. To do so, formulate your question to make sure it's clear (follow the guidelines in <https://kcd.im/ask>) and a <https://kcd.im/repro> helps a lot if applicable. Then post it to ${officeHoursChannel} or join the meeting and ask live. Kent streams/records his office hours on YouTube so even if you can't make it in person, you should be able to watch his answer later.`,
   )
 }
 officeHours.description =


### PR DESCRIPTION
**What**:

These changes fix a typo in the botofficehours message and add a suggestion on how to improve the botask message.

**Why**:

Because typos are bad and clear bot answers are nice. 😇

**How**:

I have adjusted the tests to reflect the bot messages I expected and then fixed the texts itself.

**Checklist**:

- [ ] Documentation N/A
- [X] Tests
- [X] Ready to be merged

Yes, in my opinion this is ready to merge, unless my English in the bot messages can be improved or my suggestion is not an improvement.