### PR TITLE
Display name of channel rather than link in onboarding flow

### DIFF
--- a/src/onboarding/handle-new-member.ts
+++ b/src/onboarding/handle-new-member.ts
@@ -42,38 +42,37 @@ async function handleNewMember(member: TDiscord.GuildMember) {
     cat1.children.size > cat2.children.size ? 1 : -1,
   )
 
-  const channel = await member.guild.channels.create(
-    `${welcomeChannelPrefix}${username}_${discriminator}`,
-    {
-      topic: `Membership application for ${username}#${discriminator} (Member ID: "${member.id}")`,
-      reason: `To allow ${username}#${discriminator} to apply to join the community.`,
-      parent: categoryWithFewest,
-      permissionOverwrites: [
-        {
-          type: 'role',
-          id: everyoneRole.id,
-          deny: allPermissions,
-        },
-        {
-          type: 'member',
-          id: member.id,
-          allow: [
-            'ADD_REACTIONS',
-            'VIEW_CHANNEL',
-            'SEND_MESSAGES',
-            'SEND_TTS_MESSAGES',
-            'READ_MESSAGE_HISTORY',
-            'CHANGE_NICKNAME',
-          ],
-        },
-        {
-          type: 'member',
-          id: clientUser.id,
-          allow: allPermissions,
-        },
-      ],
-    },
-  )
+  const newChannelName = `${welcomeChannelPrefix}${username}_${discriminator}`
+
+  const channel = await member.guild.channels.create(newChannelName, {
+    topic: `Membership application for ${username}#${discriminator} (Member ID: "${member.id}")`,
+    reason: `To allow ${username}#${discriminator} to apply to join the community.`,
+    parent: categoryWithFewest,
+    permissionOverwrites: [
+      {
+        type: 'role',
+        id: everyoneRole.id,
+        deny: allPermissions,
+      },
+      {
+        type: 'member',
+        id: member.id,
+        allow: [
+          'ADD_REACTIONS',
+          'VIEW_CHANNEL',
+          'SEND_MESSAGES',
+          'SEND_TTS_MESSAGES',
+          'READ_MESSAGE_HISTORY',
+          'CHANGE_NICKNAME',
+        ],
+      },
+      {
+        type: 'member',
+        id: clientUser.id,
+        allow: allPermissions,
+      },
+    ],
+  })
   const send = getSend(channel)
 
   await send(
@@ -91,7 +90,7 @@ In less than 5 minutes, you'll have full access to this server. So, let's get st
   const answers = {}
   await send(await getMessageContents(firstStep.question, answers, member))
 
-  botLog(guild, () => `${member} onboarding channel created: ${channel}`)
+  botLog(guild, () => `${member} onboarding channel created: ${newChannelName}`)
 }
 
 export {handleNewMember}


### PR DESCRIPTION
Resolves: https://github.com/kentcdodds/kcd-discord-bot/issues/66

**What**:
Makes the KCD bot log the channel name during onboarding, rather than the channel link.

**Why**:
When the channel is later deleted, links to that deleted channel just render as "#deleted-channel"

**How**:
Just grabbed a variable of the name for the channel that the bot will create, and reuse that during the log

**Checklist**:

<!-- add "N/A" to the end of each line that's irrelevant to your changes -->
<!-- to check an item, place an "x" in the box like so: "- [x] Documentation" -->

- [ ] Documentation N/A
- [ ] Tests
- [ ] Ready to be merged N/A

I didn't add a test for this because there wasn't already a spec file around this area of code. But could do so if requested. 
