### PR TITLE
bot-gender notify author rather than reactor

### DIFF
--- a/src/reactions/__tests__/index.ts
+++ b/src/reactions/__tests__/index.ts
@@ -121,7 +121,7 @@ test('botgender sends the user a message in the #bot-messages channel asking the
 
   const botMsg = botMessagesChannel.lastMessage
   expect(botMsg?.content).toMatchInlineSnapshot(`
-    <@!hannah> We want all our community members to feel included and using gender neutral words helps a lot. Please edit your message (<https://discordapp.com/channels/:guildId/:channelId/:messageId>) using "friends", "people", "folks", or "everyone" instead of "guys", or similar. Read more here: https://kcd.im/coc.
+    <@!kody> We want all our community members to feel included and using gender neutral words helps a lot. Please edit your message (<https://discordapp.com/channels/:guildId/:channelId/:messageId>) using "friends", "people", "folks", or "everyone" instead of "guys", or similar. Read more here: https://kcd.im/coc.
 
     React with ✅ to confirm you understand, so this message can be automatically deleted.
   `)

--- a/src/reactions/reactions.ts
+++ b/src/reactions/reactions.ts
@@ -76,8 +76,7 @@ ${helpRequester} Here are the available bot reactions:
 }
 
 async function gender(messageReaction: TDiscord.MessageReaction) {
-  const author = messageReaction.users.cache.first()
-  if (!author) return
+  const author = messageReaction.message.author
 
   const botMessagesChannel = getTextChannel(
     messageReaction.message.guild,


### PR DESCRIPTION
**What**:

Updates the botgender reaction to notify the orginal message author, rather than the reactor. 

**Why**:

This was the intended behaviour originally. 

**How**:

Just swapped who is pinged by the bot message. 

**Checklist**:

- [ ] Documentation N/A
- [x] Tests
- [x] Ready to be merged
