### PR TITLE
Meetups: Add YouTube and WebinarGeek domains for skipping a voice channel

### DIFF
--- a/src/commands/command-fns/__tests__/meetup.ts
+++ b/src/commands/command-fns/__tests__/meetup.ts
@@ -472,18 +472,24 @@ CC: ${hannah} and ${marty}
   )
 })
 
-test('if the meetup command includes a zoom link, that is shared instead of creating a voice channel', async () => {
-  const {guild, kody, createMessage} = await setup()
+test.each([
+  ['Zoom', 'https://egghead.zoom.us/j/97341329204?pwd=MTRPc1p4UitxNTRlUT09'],
+  ['Twitch', 'https://www.twitch.tv/videos/1163705517'],
+  ['YouTube normal', 'https://www.youtube.com/watch?v=Q-S123aBcqq'],
+  ['YouTube shareable', 'https://youtu.be/Q-S123aBcqq'],
+  ['WebinarGeek', 'https://someone.webinargeek.com/test123-1'],
+])(
+  `if the meetup command includes a %s link, that is shared instead of creating a voice channel`,
+  async (_, link) => {
+    const {guild, kody, createMessage} = await setup()
 
-  await meetup(
-    createMessage(
-      `?meetup start Migrating to Tailwind https://egghead.zoom.us/j/97341329204?pwd=MTRPc1p4Uit4K2ZpVjNDSWFxNTRlUT09`,
-      kody.user,
-    ),
-  )
-  const meetupChannels = Array.from(getMeetupChannels(guild).values())
-  expect(meetupChannels).toHaveLength(0)
-})
+    await meetup(
+      createMessage(`?meetup start Migrating to Tailwind ${link}`, kody.user),
+    )
+    const meetupChannels = Array.from(getMeetupChannels(guild).values())
+    expect(meetupChannels).toHaveLength(0)
+  },
+)
 
 test('can use "TESTING" in the subject to test things out and not notify anyone', async () => {
   const {

--- a/src/commands/command-fns/meetup.ts
+++ b/src/commands/command-fns/meetup.ts
@@ -308,7 +308,7 @@ Start a new meetup right now:
 Add yourself to ${getFollowMeChannel(message.guild)}:
   \`${commandPrefix}meetup follow-me Here's a brief description about me\`
 
-NOTE: For both the schedule and start commands, if you include a Zoom link, that will be shared instead of creating a voice channel.
+NOTE: For both the schedule and start commands, if you include a Zoom, Twitch, YouTube, or WebinarGeek link, that will be shared instead of creating a voice channel.
 NOTE: If you just want to test things out and not notify people, include the text "TESTING" in your subject.
     `.trim(),
   )

--- a/src/meetup/utils.ts
+++ b/src/meetup/utils.ts
@@ -55,7 +55,7 @@ type StartMeetupOptions = {
   notificationUsers?: Array<TDiscord.GuildMember>
 }
 
-const noVoiceChannelRegex = /(zoom\.us|twitch\.tv)/i
+const noVoiceChannelRegex = /(zoom\.us|twitch\.tv|youtube\.com|youtu\.be|webinargeek\.com)/i
 
 async function startMeetup({
   host,


### PR DESCRIPTION
**What**:

When starting a meetup, a Discord voice channel is created automatically. However, if you include a link to Zoom, or Twitch, in your meetup description, no voice channel is created, but instead the link is displayed for others to click to join the meetup there.

I've added domains for some more platforms where a link should be displayed: WebinarGeek.com and YouTube.

**Why**:

Although not many meetups are being organized, having some other popular platforms that support this nice feature can be convenient. And WebinarGeek? I'll probably be the only one using it, but then at least for me it's convenient. 😊 

**How**:

I've added the following domains to the regex that determines whether a voice channel or link should be used:
* youtube.com
* youtu.be
* webinargeek.com

I've also expanded the tests for this functionality with an `.each` so every supported domain is tested now.

**Checklist**:

- [X] Documentation
- [X] Tests
- [X] Ready to be merged
